### PR TITLE
Fix Typos & Naming Consistency

### DIFF
--- a/hash/hash_test.go
+++ b/hash/hash_test.go
@@ -41,7 +41,7 @@ func TestUnmarshalCasmClassHash(t *testing.T) {
 //	none
 func TestClassHash(t *testing.T) {
 	//https://github.com/software-mansion/starknet.py/blob/development/starknet_py/hash/class_hash_test.py
-	expectedClasshash := "0x4ec2ecf58014bc2ffd7c84843c3525e5ecb0a2cac33c47e9c347f39fc0c0944"
+	expectedClassHash := "0x4ec2ecf58014bc2ffd7c84843c3525e5ecb0a2cac33c47e9c347f39fc0c0944"
 
 	content, err := os.ReadFile("./tests/hello_starknet_compiled.sierra.json")
 	require.NoError(t, err)
@@ -50,7 +50,7 @@ func TestClassHash(t *testing.T) {
 	err = json.Unmarshal(content, &class)
 	require.NoError(t, err)
 	compClassHash := hash.ClassHash(class)
-	require.Equal(t, expectedClasshash, compClassHash.String())
+	require.Equal(t, expectedClassHash, compClassHash.String())
 }
 
 // TestCompiledClassHash is a test function that verifies the correctness of the CompiledClassHash function in the hash package.

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -135,5 +135,5 @@ func ProofMerklePath(root *big.Int, leaf *big.Int, path []*big.Int) bool {
 	}
 	nextLeaf := MerkleHash(leaf, path[0])
 
-	return ProofMerklePath(root, nexLeaf, path[1:])
+	return ProofMerklePath(root, nextLeaf, path[1:])
 }

--- a/merkle/merkle.go
+++ b/merkle/merkle.go
@@ -133,7 +133,7 @@ func ProofMerklePath(root *big.Int, leaf *big.Int, path []*big.Int) bool {
 	if len(path) == 0 {
 		return root.Cmp(leaf) == 0
 	}
-	nexLeaf := MerkleHash(leaf, path[0])
+	nextLeaf := MerkleHash(leaf, path[0])
 
 	return ProofMerklePath(root, nexLeaf, path[1:])
 }

--- a/rpc/README.md
+++ b/rpc/README.md
@@ -9,7 +9,7 @@ If you need starknet.go to support another API, open an issue on the project.
 
 ### Testing the RPC API
 
-To test the RPC API, you should simply go the the rpc directory and run
+To test the RPC API, you should simply go to the rpc directory and run
 `go test` like below:
 
 ```shell
@@ -31,7 +31,7 @@ Supported environments are `mock`, `testnet` and `mainnet`. The support for
 
 If you plan to specify an alternative URL to test the environment, you can set
 the `INTEGRATION_BASE` environment variable. In addition, tests load `.env.${env}`,
-and `.env` before relying on the environment variable. So for instanve if you want
+and `.env` before relying on the environment variable. So for instance if you want
 the URL to change only for the testnet environment, you could add the line below
 in `.env.testnet`:
 


### PR DESCRIPTION
1. hash_test.go
expectedClasshash → expectedClassHash (naming consistency).
Fixed inconsistent variable reference in require.Equal.
2. merkle.go
nexLeaf → nextLeaf (typo fix).
3. README.md
Fixed typos:
"instanve" → "instance"
"go the the" → "go to the"