### PR TITLE
Update mainnetBlockReceipts588763.json data

### DIFF
--- a/rpc/tests/blockWithReceipts/mainnetBlockReceipts588763.json
+++ b/rpc/tests/blockWithReceipts/mainnetBlockReceipts588763.json
@@ -13,8 +13,8 @@
 			"price_in_wei": "0x73424cf6f"
 		},
 		"l1_data_gas_price": {
-			"price_in_fri": "0x1",
-			"price_in_wei": "0x1"
+			"price_in_fri": "0x0",
+			"price_in_wei": "0x0"
 		},
 		"l1_da_mode": "CALLDATA",
 		"starknet_version": "0.13.0",


### PR DESCRIPTION
The `l1_data_gas_price` field value was `0x1`, but now is `0x0`. This PR update it  