### PR TITLE
replace dead link README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ operations on the wallets. The package has excellent documentation for a smooth
 - [deploy account example](./examples/deployAccount) to deploy a new account contract on testnet.
 - [invoke transaction example](./examples/invoke) to add a new invoke transaction on testnet.
 - [declare transaction example](./examples/simpleDeclare) to add a new contract on testnet.
-- [deploy contract UDC example](./examples/deployContractUDC) to deploy an ERC20 token using [UDC (Universal Deployer Contract)](https://docs.starknet.io/architecture-and-concepts/accounts/universal-deployer/) on testnet.
+- [deploy contract UDC example](./examples/deployContractUDC) to deploy an ERC20 token using [UDC (Universal Deployer Contract)](https://docs.openzeppelin.com/contracts-cairo/0.12.0/udc) on testnet.
 - [typed data example](./examples/typedData) to sign and verify a typed data.
 - [websocket example](./examples/websocket) to learn how to subscribe to WebSocket methods.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ operations on the wallets. The package has excellent documentation for a smooth
 - [deploy account example](./examples/deployAccount) to deploy a new account contract on testnet.
 - [invoke transaction example](./examples/invoke) to add a new invoke transaction on testnet.
 - [declare transaction example](./examples/simpleDeclare) to add a new contract on testnet.
-- [deploy contract UDC example](./examples/deployContractUDC) to deploy an ERC20 token using [UDC (Universal Deployer Contract)](https://docs.openzeppelin.com/contracts-cairo/0.12.0/udc) on testnet.
+- [deploy contract UDC example](./examples/deployContractUDC) to deploy an ERC20 token using [UDC (Universal Deployer Contract)](https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc) on testnet.
 - [typed data example](./examples/typedData) to sign and verify a typed data.
 - [websocket example](./examples/websocket) to learn how to subscribe to WebSocket methods.
 


### PR DESCRIPTION
Fixed dead link:

https://docs.starknet.io/architecture-and-concepts/accounts/universal-deployer/ - dead 
https://docs.openzeppelin.com/contracts-cairo/0.12.0/udc - new link

https://docs.starknet.io/architecture-and-concepts/accounts/#deploying_a_new_account At this link, the documentation redirects to a new one. If you have a better replacement option for the link, I’d really appreciate it.