### PR TITLE
Thiagodeev/Spy feature for testing JSON-RPC calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The internal `tryUnwrapToRPCErr` func of the `rpc` pkg was renamed to `UnwrapToRPCErr` and moved to the new package.
   - The `Err` function now have a specific case for the `InternalError` code.
 
+### Dev updates
+- New `internal/tests/jsonrpc_spy.go` file containing a `spy` type for spying JSON-RPC calls in tests. The
+old `rpc/spy_test.go` file was removed.
+
 ## [0.15.0](https://github.com/NethermindEth/starknet.go/releases/tag/v0.15.0) - 2025-09-03
 ### Changed
 - The following functions now return the response as a value instead of a pointer:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/NethermindEth/juno v0.14.0
 	github.com/gorilla/websocket v1.5.3
 	github.com/joho/godotenv v1.4.0
-	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.5.0
 	golang.org/x/crypto v0.36.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/mmcloughlin/addchain v0.4.0/go.mod h1:A86O+tHqZLMNO4w6ZZ4FlVQEadcoqky
 github.com/mmcloughlin/profile v0.1.1/go.mod h1:IhHD7q1ooxgwTgjxQYkACGA77oFTDdFVejUS1/tS/qU=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
-github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
-github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -23,7 +23,7 @@ type callCloser interface {
 
 var _ callCloser = &spy{}
 
-// NewSpy creates a new spy object.
+// NewJSONRPCSpy creates a new spy object.
 //
 // It takes a client callCloser as the first parameter and an optional debug parameter.
 // The client callCloser is the interface that the spy will be based on.
@@ -35,7 +35,7 @@ var _ callCloser = &spy{}
 //
 // Returns:
 //   - spy: a new spy object
-func NewSpy(client callCloser, debug ...bool) *spy {
+func NewJSONRPCSpy(client callCloser, debug ...bool) *spy {
 	d := false
 	if len(debug) > 0 {
 		d = debug[0]

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -4,9 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"github.com/NethermindEth/starknet.go/client/rpcerr"
-	"github.com/nsf/jsondiff"
 )
 
 type spy struct {
@@ -133,39 +130,4 @@ func (s *spy) CallContextWithSliceArgs(ctx context.Context, result interface{}, 
 	s.s = []byte(raw)
 
 	return err
-}
-
-// Compare compares the spy object with the given object and returns the difference between them.
-//
-// Parameters:
-//   - o: the object to compare with the spy object
-//   - debug: a boolean flag indicating whether to print debug information
-//
-// Returns:
-//   - string: the difference between the spy object and the given object
-//   - error: an error if any occurred during the comparison
-func (s *spy) Compare(o interface{}, debug bool) (string, error) {
-	if s.mock {
-		if debug {
-			fmt.Println("**************************")
-			fmt.Println("This is a mock")
-			fmt.Println("**************************")
-		}
-
-		return "FullMatch", nil
-	}
-	b, err := json.Marshal(o)
-	if err != nil {
-		return "", rpcerr.Err(rpcerr.InternalError, rpcerr.StringErrData(err.Error()))
-	}
-	diff, _ := jsondiff.Compare(s.s, b, &jsondiff.Options{})
-	if debug {
-		fmt.Println("**************************")
-		fmt.Println(string(s.s))
-		fmt.Println("**************************")
-		fmt.Println(string(b))
-		fmt.Println("**************************")
-	}
-
-	return diff.String(), nil
 }

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -8,7 +8,7 @@ import (
 
 type spy struct {
 	callCloser
-	s     []byte
+	buff  json.RawMessage
 	mock  bool
 	debug bool
 }
@@ -43,7 +43,7 @@ func NewSpy(client callCloser, debug ...bool) *spy {
 	if TEST_ENV == MockEnv {
 		return &spy{
 			callCloser: client,
-			s:          []byte{},
+			buff:       []byte{},
 			mock:       true,
 			debug:      d,
 		}
@@ -51,7 +51,7 @@ func NewSpy(client callCloser, debug ...bool) *spy {
 
 	return &spy{
 		callCloser: client,
-		s:          []byte{},
+		buff:       []byte{},
 		debug:      d,
 	}
 }
@@ -90,7 +90,7 @@ func (s *spy) CallContext(ctx context.Context, result interface{}, method string
 	}
 
 	err = json.Unmarshal(raw, result)
-	s.s = []byte(raw)
+	s.buff = raw
 
 	return err
 }
@@ -131,9 +131,15 @@ func (s *spy) CallContextWithSliceArgs(ctx context.Context, result interface{}, 
 	}
 
 	err = json.Unmarshal(raw, result)
-	s.s = []byte(raw)
+	s.buff = raw
 
 	return err
+}
+
+// LastResponse returns the last response captured by the spy.
+// In other words, it returns the raw JSON response received from the server when calling a `callCloser` method.
+func (s *spy) LastResponse() json.RawMessage {
+	return s.buff
 }
 
 // PrettyPrint pretty marshals the data with indentation and prints it.

--- a/internal/tests/jsonrpc_spy.go
+++ b/internal/tests/jsonrpc_spy.go
@@ -21,7 +21,7 @@ type callCloser interface {
 	Close()
 }
 
-var _ callCloser = &spy{}
+var _ callCloser = &spy{} //nolint:exhaustruct
 
 // NewJSONRPCSpy creates a new spy object.
 //
@@ -52,6 +52,7 @@ func NewJSONRPCSpy(client callCloser, debug ...bool) *spy {
 	return &spy{
 		callCloser: client,
 		buff:       []byte{},
+		mock:       false,
 		debug:      d,
 	}
 }

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -433,21 +433,6 @@ func TestBlockWithTxs(t *testing.T) {
 }
 
 // TestBlockTransactionCount tests the function that calculates the number of transactions in a block.
-//
-// This function tests the BlockTransactionCount function by running it with different test cases.
-// It verifies that the function returns the expected count of transactions for each test case.
-// The test cases include a mock environment, a testnet environment, and a mainnet environment.
-// For each test case, the function sets up a spy provider and calls BlockTransactionCount with a specific block ID.
-// It then compares the returned count with the expected count and verifies that they match.
-// If the counts do not match, the function reports an error and provides additional information.
-// Finally, the function terminates if all test cases pass.
-//
-// Parameters:
-//   - t: the testing object for running the test cases
-//
-// Returns:
-//
-//	none
 func TestBlockTransactionCount(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv, tests.TestnetEnv, tests.IntegrationEnv)
 
@@ -590,19 +575,6 @@ func TestCaptureUnsupportedBlockTxn(t *testing.T) {
 }
 
 // TestStateUpdate is a test function for the StateUpdate method.
-//
-// It tests the StateUpdate method by creating a test set and iterating through each test case.
-// For each test case, it creates a spy object and sets it as the provider.
-// Then, it calls the StateUpdate method with the given test block ID.
-// If there is an error, it fails the test.
-// If the returned block hash does not match the expected block hash, it fails the test.
-//
-// Parameters:
-//   - t: the testing object for running the test cases
-//
-// Returns:
-//
-//	none
 func TestStateUpdate(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv, tests.TestnetEnv, tests.IntegrationEnv)
 
@@ -657,8 +629,6 @@ func TestStateUpdate(t *testing.T) {
 	}[tests.TEST_ENV]
 	for _, test := range testSet {
 		t.Run(fmt.Sprintf("BlockID: %v", test.BlockID), func(t *testing.T) {
-			spy := tests.NewSpy(testConfig.Provider.c)
-			testConfig.Provider.c = spy
 			stateUpdate, err := testConfig.Provider.StateUpdate(context.Background(), test.BlockID)
 			require.NoError(t, err, "Unable to fetch the given block.")
 

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -657,7 +657,7 @@ func TestStateUpdate(t *testing.T) {
 	}[tests.TEST_ENV]
 	for _, test := range testSet {
 		t.Run(fmt.Sprintf("BlockID: %v", test.BlockID), func(t *testing.T) {
-			spy := NewSpy(testConfig.Provider.c)
+			spy := tests.NewSpy(testConfig.Provider.c)
 			testConfig.Provider.c = spy
 			stateUpdate, err := testConfig.Provider.StateUpdate(context.Background(), test.BlockID)
 			require.NoError(t, err, "Unable to fetch the given block.")

--- a/rpc/chain_test.go
+++ b/rpc/chain_test.go
@@ -12,18 +12,6 @@ import (
 )
 
 // TestChainID is a function that tests the ChainID function in the Go test file.
-//
-// The function initialises a test configuration and defines a test set with different chain IDs for different environments.
-// It then iterates over the test set and for each test, creates a new spy and sets the spy as the provider's client.
-// The function calls the ChainID function and compares the returned chain ID with the expected chain ID.
-// If there is a mismatch or an error occurs, the function logs a fatal error.
-//
-// Parameters:
-//   - t: the testing object for running the test cases
-//
-// Returns:
-//
-//	none
 func TestChainID(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv, tests.TestnetEnv, tests.MainnetEnv, tests.DevnetEnv, tests.IntegrationEnv)
 

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -11,25 +11,6 @@ import (
 )
 
 // TestEvents is a test function for testing the Events function.
-//
-// It creates a test configuration and defines a test set with different scenarios for the Events function.
-// The test set includes a "mock" scenario and a "mainnet" scenario.
-// In the "mock" scenario, it sets up the event filter, result page request, and expected response.
-// In the "mainnet" scenario, it sets up the event filter, result page request, and expected response.
-// It then iterates through the test set and performs the following steps for each test:
-//   - Creates a spy object.
-//   - Sets the provider's context to the spy object.
-//   - Sets up the event input with the event filter and result page request.
-//   - Calls the Events function with the event input.
-//   - Checks if there is an error and fails the test if there is.
-//   - Compares the events' block hash, block number, and transaction hash with the expected response.
-//
-// Parameters:
-//   - t: the testing object for running the test cases
-//
-// Returns:
-//
-//	none
 func TestEvents(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv, tests.TestnetEnv, tests.MainnetEnv, tests.IntegrationEnv)
 

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -78,20 +78,6 @@ func TestTransactionByHash(t *testing.T) {
 }
 
 // TestTransactionByBlockIdAndIndex tests the TransactionByBlockIdAndIndex function.
-//
-// It sets up a test environment and defines a test set. For each test in the set,
-// it creates a spy object and assigns it to the provider's c field. It then calls
-// the TransactionByBlockIdAndIndex function with the specified block ID and index.
-// If there is an error, it fails the test. If the transaction is nil, it fails the test.
-// If the transaction is not of type InvokeTxn3, it fails the test. Finally, it asserts
-// that the transaction type is TransactionType_Invoke and that the transaction is equal to the expected transaction.
-//
-// Parameters:
-//   - t: the testing object for running the test cases
-//
-// Returns:
-//
-//	none
 func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv, tests.TestnetEnv, tests.IntegrationEnv)
 
@@ -212,8 +198,6 @@ func TestTransactionReceipt(t *testing.T) {
 	}[tests.TEST_ENV]
 
 	for _, test := range testSet {
-		spy := tests.NewSpy(testConfig.Provider.c)
-		testConfig.Provider.c = spy
 		txReceiptWithBlockInfo, err := testConfig.Provider.TransactionReceipt(context.Background(), test.TxnHash)
 		require.Nil(t, err)
 		require.Equal(t, test.ExpectedResp, *txReceiptWithBlockInfo)

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -212,7 +212,7 @@ func TestTransactionReceipt(t *testing.T) {
 	}[tests.TEST_ENV]
 
 	for _, test := range testSet {
-		spy := NewSpy(testConfig.Provider.c)
+		spy := tests.NewSpy(testConfig.Provider.c)
 		testConfig.Provider.c = spy
 		txReceiptWithBlockInfo, err := testConfig.Provider.TransactionReceipt(context.Background(), test.TxnHash)
 		require.Nil(t, err)


### PR DESCRIPTION
This PR aims to take the current `rpc/spy_test.go` file content and make it a general internal test tool for spying JSON-RPC request using a `callCloser` client interface.