### PR TITLE
Thiagodeev/Fix SNIP-12 JSON Marshaling for TypedData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The internal `tryUnwrapToRPCErr` func of the `rpc` pkg was renamed to `UnwrapToRPCErr` and moved to the new package.
   - The `Err` function now have a specific case for the `InternalError` code.
 
+### Fixed
+- The `typedData.TypedData` was not being marshaled exactly as it is in the original JSON. Now, the original JSON is preserved,
+  so the output of `TypedData.MarshalJSON()` is exactly as the original JSON.
+
 ### Dev updates
 - New `internal/tests/jsonrpc_spy.go` file containing a `Spy` type for spying JSON-RPC calls in tests. The
 old `rpc/spy_test.go` file was removed.
 - New `mocks/mock_client.go` file containing a mock of the `client.Client` type (`client.ClientI` interface).
+- New benchmarks and tests for the `typedData` pkg.
 
 ## [0.15.0](https://github.com/NethermindEth/starknet.go/releases/tag/v0.15.0) - 2025-09-03
 ### Changed

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -991,7 +991,7 @@ func (domain Domain) MarshalJSON() ([]byte, error) {
 	} else {
 		chainId, err = strconv.Atoi(domain.ChainId)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("cannot parse 'chain_id' value: %w", err)
 		}
 	}
 

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -426,8 +426,16 @@ func EncodeData(typeDef *TypeDefinition, td *TypedData, context ...string) (enc 
 			return enc, err
 		}
 
+		// The ChainId can be either `chainId` or `chain_id`.
 		// ref: https://community.starknet.io/t/signing-transactions-and-off-chain-messages/66
-		domainMap["chain_id"] = domainMap["chainId"]
+		// We find the one that contains the value and we copy the value to the other field.
+		// It's an workaround to handle both cases.
+
+		if domainMap["chainId"] != nil {
+			domainMap["chain_id"] = domainMap["chainId"]
+		} else {
+			domainMap["chainId"] = domainMap["chain_id"]
+		}
 
 		return encodeData(typeDef, td, domainMap, false, context...)
 	}
@@ -994,7 +1002,7 @@ func (domain Domain) MarshalJSON() ([]byte, error) {
 		revision = nil
 	} else {
 		if domain.HasStringRevision {
-			revision = fmt.Sprintf("%v", domain.Revision)
+			revision = strconv.FormatUint(uint64(domain.Revision), 10)
 		} else {
 			revision = domain.Revision
 		}

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -940,9 +940,6 @@ func (domain *Domain) UnmarshalJSON(data []byte) error {
 	rawChainId, ok := dec["chainId"]
 	if !ok {
 		err = errors.New("error getting the value of 'chainId' from 'domain' JSON field")
-	}
-
-	if err != nil {
 		if numRevision == 1 {
 			return err
 		}

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -899,7 +899,7 @@ func (domain *Domain) UnmarshalJSON(data []byte) error {
 	getField := func(fieldName string) (string, error) {
 		value, ok := dec[fieldName]
 		if !ok {
-			return "", fmt.Errorf("error getting the value of '%s' from 'domain' struct", fieldName)
+			return "", fmt.Errorf("error getting the value of '%s' from 'domain' JSON field", fieldName)
 		}
 
 		return fmt.Sprintf("%v", value), nil
@@ -939,7 +939,7 @@ func (domain *Domain) UnmarshalJSON(data []byte) error {
 	// used to marshal the ChainId exactly as it is in the original JSON.
 	rawChainId, ok := dec["chainId"]
 	if !ok {
-		err = errors.New("error getting the value of 'chainId' from 'domain' struct")
+		err = errors.New("error getting the value of 'chainId' from 'domain' JSON field")
 	}
 
 	if err != nil {
@@ -951,7 +951,7 @@ func (domain *Domain) UnmarshalJSON(data []byte) error {
 		// ref: https://community.starknet.io/t/signing-transactions-and-off-chain-messages/66
 		rawChainId, ok = dec["chain_id"]
 		if !ok {
-			err2 := errors.New("error getting the value of 'chain_id' from 'domain' struct")
+			err2 := errors.New("error getting the value of 'chain_id' from 'domain' JSON field")
 
 			return fmt.Errorf("%w: %w", err, err2)
 		}

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -933,3 +933,8 @@ func (domain *Domain) UnmarshalJSON(data []byte) error {
 
 	return nil
 }
+
+// MarshalJSON implements the json.Marshaler interface for TypeDefinition
+func (td TypeDefinition) MarshalJSON() ([]byte, error) {
+	return json.Marshal(td.Parameters)
+}

--- a/typedData/typedData.go
+++ b/typedData/typedData.go
@@ -19,11 +19,11 @@ import (
 var typeNameRegexp = regexp.MustCompile(`[^\(\),\s]+`)
 
 type TypedData struct {
-	Types       map[string]TypeDefinition
-	PrimaryType string
-	Domain      Domain
-	Message     map[string]any
-	Revision    *revision
+	Types       map[string]TypeDefinition `json:"types"`
+	PrimaryType string                    `json:"primaryType"`
+	Domain      Domain                    `json:"domain"`
+	Message     map[string]any            `json:"message"`
+	Revision    *revision                 `json:"-"`
 }
 
 type Domain struct {

--- a/typedData/typedData_test.go
+++ b/typedData/typedData_test.go
@@ -80,6 +80,22 @@ func BenchmarkGetMessageHash(b *testing.B) {
 	}
 }
 
+// TestMarshalJSON tests the MarshalJSON function. It marshals the TypedData and compares the result
+// with the original raw data.
+func TestMarshalJSON(t *testing.T) {
+	for _, filename := range fileNames {
+		t.Run(filename, func(t *testing.T) {
+			rawData, err := os.ReadFile(fmt.Sprintf("./testData/%s.json", filename))
+			require.NoError(t, err)
+
+			marshaledData, err := json.Marshal(typedDataExamples[filename])
+			require.NoError(t, err)
+
+			require.JSONEq(t, string(rawData), string(marshaledData))
+		})
+	}
+}
+
 // TestMessageHash tests the GetMessageHash function.
 //
 // It creates a mock TypedData and sets up a test case for hashing a mail message.

--- a/typedData/typedData_test.go
+++ b/typedData/typedData_test.go
@@ -10,19 +10,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var typedDataExamples = make(map[string]TypedData)
-var fileNames = []string{
-	"baseExample",
-	"example_array",
-	"example_baseTypes",
-	"example_enum",
-	"example_presetTypes",
-	"mail_StructArray",
-	"session_MerkleTree",
-	"v1Nested",
-	"allInOne",
-	"example_enumNested",
-}
+var (
+	typedDataExamples = make(map[string]TypedData)
+	fileNames         = []string{
+		"baseExample",
+		"example_array",
+		"example_baseTypes",
+		"example_enum",
+		"example_presetTypes",
+		"mail_StructArray",
+		"session_MerkleTree",
+		"v1Nested",
+		"allInOne",
+		"example_enumNested",
+	}
+)
 
 // TestMain initialises test data by loading TypedData examples from JSON files.
 // It reads multiple test files and stores them in the typedDataExamples map
@@ -74,7 +76,10 @@ func BenchmarkGetMessageHash(b *testing.B) {
 	for key, typedData := range typedDataExamples {
 		b.Run(key, func(b *testing.B) {
 			for b.Loop() {
-				typedData.GetMessageHash(addr)
+				_, err := typedData.GetMessageHash(addr)
+				if err != nil {
+					b.Fatal(err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Problem
The TypedData struct wasn't preserving the original JSON format when marshaling/unmarshaling, causing issues with SNIP-12 compliance and backward compatibility. It was also invalid in some points.

Solution
- Added JSON tags to the `TypedData` struct
- Added custom JSON marshaling for `Domain` and `TypeDefinition` structs
- Support both `chainId` and `chain_id` field names for backward compatibility
- Preserve original data types (string vs numeric) in marshaled output

Key Changes
- Custom UnmarshalJSON/MarshalJSON methods for exact JSON preservation
- Internal flags to track original field types and naming
- New test TestMarshalJSON to validate output matches input
- New benchmark BenchmarkUnmarshalJSON for performance testing

Testing
✅ All linting issues resolved
✅ New tests pass and validate exact JSON preservation
✅ Backward compatibility maintained
✅ Performance benchmarks added