### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/typeddata/typedData.go
+++ b/typeddata/typedData.go
@@ -344,18 +344,18 @@ func encodeTypes(
 		for i, param := range typeDef.Parameters {
 			if len(isEnum) != 0 {
 				typesArr := typeNameRegexp.FindAllString(param.Type, -1)
-				var fullTypeName string
+				var fullTypeName strings.Builder
 				for i, typeNam := range typesArr {
-					fullTypeName += `"` + typeNam + `"`
+					fullTypeName.WriteString(`"` + typeNam + `"`)
 					if i < (len(typesArr) - 1) {
-						fullTypeName += `,`
+						fullTypeName.WriteString(`,`)
 					}
 				}
 				buf.WriteString(
 					fmt.Sprintf(
 						quotationMark+"%s"+quotationMark+":"+`(`+"%s"+`)`,
 						param.Name,
-						fullTypeName,
+						fullTypeName.String(),
 					),
 				)
 


### PR DESCRIPTION

strings.Builder has fewer memory allocations and better performance.

More info: [golang/go#75190](https://github.com/golang/go/issues/75190)
