### PR TITLE
Paymaster PR 2: add `paymaster_buildTransaction` method + tests

### DIFF
--- a/paymaster/build_txn.go
+++ b/paymaster/build_txn.go
@@ -23,7 +23,7 @@ import (
 //   - error: An error if the request fails
 func (p *Paymaster) BuildTransaction(
 	ctx context.Context,
-	request BuildTransactionRequest,
+	request *BuildTransactionRequest,
 ) (BuildTransactionResponse, error) {
 	var response BuildTransactionResponse
 	if err := p.c.CallContextWithSliceArgs(

--- a/paymaster/build_txn.go
+++ b/paymaster/build_txn.go
@@ -1,0 +1,336 @@
+package paymaster
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/client/rpcerr"
+	"github.com/NethermindEth/starknet.go/typedData"
+)
+
+// BuildTransaction receives the transaction the user wants to execute. Returns the typed
+// data along with the estimated gas cost and the maximum gas cost suggested to ensure execution
+//
+// Parameters:
+//   - ctx: The context.Context object for controlling the function call
+//   - request: The BuildTransactionRequest containing the transaction and parameters
+//
+// Returns:
+//   - *BuildTransactionResponse: The response containing typed data and fee estimate
+//   - error: An error if the request fails
+func (p *Paymaster) BuildTransaction(ctx context.Context, request *BuildTransactionRequest) (*BuildTransactionResponse, error) {
+	var response BuildTransactionResponse
+	if err := p.c.CallContextWithSliceArgs(ctx, &response, "paymaster_buildTransaction", request); err != nil {
+		return nil, rpcerr.UnwrapToRPCErr(
+			err,
+			ErrInvalidAddress,
+			ErrClassHashNotSupported,
+			ErrInvalidDeploymentData,
+			ErrTokenNotSupported,
+			ErrInvalidTimeBounds,
+			ErrUnknownError,
+			ErrTransactionExecutionError,
+		)
+	}
+
+	return &response, nil
+}
+
+// BuildTransactionRequest is the request to build a transaction for the paymaster (transaction + parameters).
+type BuildTransactionRequest struct {
+	// The transaction to be executed by the paymaster
+	Transaction *UserTransaction `json:"transaction"`
+	// Execution parameters to be used when executing the transaction
+	Parameters *UserParameters `json:"parameters"`
+}
+
+// UserTransaction represents a user transaction (deploy, invoke, or deploy_and_invoke).
+type UserTransaction struct {
+	// The type of the transaction to be executed by the paymaster
+	Type UserTxnType `json:"type"`
+	// The deployment data for the transaction, used for `deploy` and `deploy_and_invoke` transaction types.
+	// Should be `nil` for `invoke` transaction types.
+	Deployment *AccDeploymentData `json:"deployment,omitempty"`
+	// The invoke data for the transaction, used for `invoke` and `deploy_and_invoke` transaction types.
+	// Should be `nil` for `deploy` transaction types.
+	Invoke *UserInvoke `json:"invoke,omitempty"`
+}
+
+// An enum representing the type of the transaction to be executed by the paymaster
+type UserTxnType string
+
+const (
+	// Represents a deploy transaction
+	UserTxnDeploy UserTxnType = "deploy"
+	// Represents an invoke transaction
+	UserTxnInvoke UserTxnType = "invoke"
+	// Represents a deploy and invoke transaction
+	UserTxnDeployAndInvoke UserTxnType = "deploy_and_invoke"
+)
+
+// MarshalJSON marshals the UserTxnType to JSON.
+func (u UserTxnType) MarshalJSON() ([]byte, error) {
+	switch u {
+	case UserTxnDeploy, UserTxnInvoke, UserTxnDeployAndInvoke:
+		return json.Marshal(string(u))
+	}
+
+	return nil, fmt.Errorf("invalid user transaction type: %s", u)
+}
+
+// UnmarshalJSON unmarshals the JSON data into a UserTxnType.
+func (u *UserTxnType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "deploy":
+		*u = UserTxnDeploy
+	case "invoke":
+		*u = UserTxnInvoke
+	case "deploy_and_invoke":
+		*u = UserTxnDeployAndInvoke
+	default:
+		return fmt.Errorf("invalid user transaction type: %s", s)
+	}
+
+	return nil
+}
+
+// Data required to deploy an account at an address.
+type AccDeploymentData struct {
+	// The expected address to be deployed, used to double check
+	Address *felt.Felt `json:"address"`
+	// The hash of the deployed contract's class
+	ClassHash *felt.Felt `json:"class_hash"`
+	// The salt used for the contract address calculation
+	Salt *felt.Felt `json:"salt"`
+	// The parameters passed to the constructor
+	ConstructorCalldata []*felt.Felt `json:"calldata"`
+	// Optional array of felts to be added to the signature
+	SignatureData []*felt.Felt `json:"sigdata,omitempty"`
+	// The Cairo version of the account contract (e.g. 1 or 2). Cairo 0 is not supported.
+	Version uint8 `json:"version"`
+}
+
+// Calls to be executed by the paymaster and the user account address that will be called
+type UserInvoke struct {
+	// The address of the user account
+	UserAddress *felt.Felt `json:"user_address"`
+	// The sequence of calls that the user wishes to perform
+	Calls []Call `json:"calls"`
+}
+
+// The object that defines an invocation of a function in a contract
+type Call struct {
+	// The address of the contract to invoke
+	To *felt.Felt `json:"to"`
+	// The selector of the function to invoke
+	Selector *felt.Felt `json:"selector"`
+	// The parameters passed to the function
+	Calldata []*felt.Felt `json:"calldata"`
+}
+
+// Execution parameters to be used when executing the transaction through the paymaster
+type UserParameters struct {
+	// Version of the execution parameters which is not tied to the 'execute from outside' version.
+	Version UserParamVersion `json:"version"`
+	// Fee mode to use for the execution
+	FeeMode FeeMode `json:"fee_mode"`
+	// Optional. Time constraint on the execution
+	TimeBounds *TimeBounds `json:"time_bounds"`
+}
+
+// An enum representing the version of the execution parameters
+type UserParamVersion string
+
+const (
+	// Represents the v1 of the execution parameters
+	UserParamV1 UserParamVersion = "0x1"
+)
+
+// MarshalJSON marshals the UserParamVersion to JSON.
+func (v UserParamVersion) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(v))
+}
+
+// UnmarshalJSON unmarshals the JSON data into a UserParamVersion.
+func (v *UserParamVersion) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+	switch s {
+	case "0x1":
+		*v = UserParamV1
+	default:
+		return fmt.Errorf("invalid user parameter version: %s", s)
+	}
+
+	return nil
+}
+
+// An enum representing the fee mode to use for the transaction
+type FeeModeType string
+
+const (
+	// Specify that the transaction should be sponsored. This argument does not
+	// guaranteed sponsorship and will depend on the paymaster provider
+	FeeModeSponsored FeeModeType = "sponsored"
+	// Default fee mode where the transaction is paid by the user in the given gas token
+	FeeModeDefault FeeModeType = "default"
+)
+
+// MarshalJSON marshals the FeeModeType to JSON.
+func (feeMode FeeModeType) MarshalJSON() ([]byte, error) {
+	switch feeMode {
+	case FeeModeSponsored, FeeModeDefault:
+		return json.Marshal(string(feeMode))
+	}
+
+	return nil, fmt.Errorf("invalid fee mode: %s", feeMode)
+}
+
+// UnmarshalJSON unmarshals the JSON data into a FeeModeType.
+func (feeMode *FeeModeType) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil {
+		return err
+	}
+
+	switch s {
+	case "sponsored":
+		*feeMode = FeeModeSponsored
+	case "default":
+		*feeMode = FeeModeDefault
+	default:
+		return fmt.Errorf("invalid fee mode: %s", s)
+	}
+
+	return nil
+}
+
+// Specify how the transaction should be paid. Either by the user specifying a gas token or through sponsorship
+type FeeMode struct {
+	// The fee mode type to use for the transaction
+	Mode FeeModeType `json:"mode"`
+	// The gas token to use for the transaction. Should be omitted for `sponsored` fee mode
+	GasToken *felt.Felt `json:"gas_token,omitempty"`
+	// Relative tip priority or a custom tip value. If not provided/is `nil`, the paymaster will use the `normal` tip priority by default.
+	Tip *TipPriority `json:"tip,omitempty"`
+}
+
+// Relative tip priority or a custom tip value.
+//
+// The user must specify either the priority or the custom tip value.
+// If both fields are omitted (or TipPriority is `nil`), the paymaster will use the `normal` tip priority by default.
+type TipPriority struct {
+	// The relative tip priority
+	Priority TipPriorityEnum `json:"-"`
+	// A custom tip value
+	Custom *uint64 `json:"custom,omitempty"`
+}
+
+// MarshalJSON marshals the TipPriority to JSON.
+func (t *TipPriority) MarshalJSON() ([]byte, error) {
+	if t.Priority != "" {
+		switch t.Priority {
+		case TipPrioritySlow:
+			return json.Marshal(TipPrioritySlow)
+		case TipPriorityNormal:
+			return json.Marshal(TipPriorityNormal)
+		case TipPriorityFast:
+			return json.Marshal(TipPriorityFast)
+		default:
+			return nil, fmt.Errorf("invalid tip priority: %s", t.Priority)
+		}
+	}
+
+	if t.Custom == nil {
+		return nil, nil
+	}
+
+	// Marshal the `custom` field
+	type alias TipPriority
+
+	return json.Marshal(alias(*t))
+}
+
+// UnmarshalJSON unmarshals the JSON data into a TipPriority.
+func (t *TipPriority) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err == nil {
+		switch s {
+		case "slow":
+			t.Priority = TipPrioritySlow
+		case "normal":
+			t.Priority = TipPriorityNormal
+		case "fast":
+			t.Priority = TipPriorityFast
+		default:
+			return fmt.Errorf("invalid tip priority: %s", s)
+		}
+
+		return nil
+	}
+
+	type Alias TipPriority
+	var alias Alias
+
+	if err := json.Unmarshal(b, &alias); err != nil {
+		return fmt.Errorf("failed to unmarshal custom tip: %w", err)
+	}
+
+	t.Custom = alias.Custom
+
+	return nil
+}
+
+// Relative tip priority
+type TipPriorityEnum string
+
+const (
+	// Relative tip priority
+	TipPrioritySlow TipPriorityEnum = "slow"
+	// Relative tip priority
+	TipPriorityNormal TipPriorityEnum = "normal"
+	// Relative tip priority
+	TipPriorityFast TipPriorityEnum = "fast"
+)
+
+// Object containing timestamps corresponding to `Execute After` and `Execute Before`
+type TimeBounds struct {
+	// A lower bound after which an outside call is valid in UNIX timestamp format
+	ExecuteAfter string `json:"execute_after"`
+	// An upper bound before which an outside call is valid in UNIX timestamp format
+	ExecuteBefore string `json:"execute_before"`
+}
+
+// FeeEstimate is a detailed fee estimation (in STRK and gas token, with suggested max).
+type FeeEstimate struct {
+	GasTokenPriceInStrk       *felt.Felt `json:"gas_token_price_in_strk"`
+	EstimatedFeeInStrk        *felt.Felt `json:"estimated_fee_in_strk"`
+	EstimatedFeeInGasToken    *felt.Felt `json:"estimated_fee_in_gas_token"`
+	SuggestedMaxFeeInStrk     *felt.Felt `json:"suggested_max_fee_in_strk"`
+	SuggestedMaxFeeInGasToken *felt.Felt `json:"suggested_max_fee_in_gas_token"`
+}
+
+// BuildTransactionResponse is the response from the `paymaster_buildTransaction` method.
+// It contains the transaction data required for the paymaster to execute, along with an estimation of the fee.
+type BuildTransactionResponse struct {
+	// The type of the transaction
+	Type UserTxnType `json:"type"`
+	// The deployment data for `deploy` and `deploy_and_invoke` transaction types.
+	// It's `nil` for `invoke` transaction types.
+	Deployment *AccDeploymentData `json:"deployment,omitempty"`
+	// Execution parameters to be used when executing the transaction
+	Parameters *UserParameters `json:"parameters"`
+	// The typed data for for `invoke` and `deploy_and_invoke` transaction types.
+	// It's `nil` for `deploy` transaction types.
+	TypedData *typedData.TypedData `json:"typed_data,omitempty"`
+	// The fee estimation for the transaction
+	Fee *FeeEstimate `json:"fee"`
+}

--- a/paymaster/build_txn.go
+++ b/paymaster/build_txn.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/client/rpcerr"
-	"github.com/NethermindEth/starknet.go/typedData"
+	"github.com/NethermindEth/starknet.go/typedata"
 )
 
 // BuildTransaction receives the transaction the user wants to execute. Returns the typed
@@ -20,9 +20,14 @@ import (
 // Returns:
 //   - *BuildTransactionResponse: The response containing typed data and fee estimate
 //   - error: An error if the request fails
-func (p *Paymaster) BuildTransaction(ctx context.Context, request *BuildTransactionRequest) (*BuildTransactionResponse, error) {
+func (p *Paymaster) BuildTransaction(
+	ctx context.Context,
+	request *BuildTransactionRequest,
+) (*BuildTransactionResponse, error) {
 	var response BuildTransactionResponse
-	if err := p.c.CallContextWithSliceArgs(ctx, &response, "paymaster_buildTransaction", request); err != nil {
+	if err := p.c.CallContextWithSliceArgs(
+		ctx, &response, "paymaster_buildTransaction", request,
+	); err != nil {
 		return nil, rpcerr.UnwrapToRPCErr(
 			err,
 			ErrInvalidAddress,
@@ -38,7 +43,8 @@ func (p *Paymaster) BuildTransaction(ctx context.Context, request *BuildTransact
 	return &response, nil
 }
 
-// BuildTransactionRequest is the request to build a transaction for the paymaster (transaction + parameters).
+// BuildTransactionRequest is the request to build a transaction for
+// the paymaster (transaction + parameters).
 type BuildTransactionRequest struct {
 	// The transaction to be executed by the paymaster
 	Transaction *UserTransaction `json:"transaction"`
@@ -46,19 +52,23 @@ type BuildTransactionRequest struct {
 	Parameters *UserParameters `json:"parameters"`
 }
 
-// UserTransaction represents a user transaction (deploy, invoke, or deploy_and_invoke).
+// UserTransaction represents a user transaction (deploy, invoke,
+// or deploy_and_invoke).
 type UserTransaction struct {
 	// The type of the transaction to be executed by the paymaster
 	Type UserTxnType `json:"type"`
-	// The deployment data for the transaction, used for `deploy` and `deploy_and_invoke` transaction types.
+	// The deployment data for the transaction, used for `deploy` and
+	// `deploy_and_invoke` transaction types.
 	// Should be `nil` for `invoke` transaction types.
 	Deployment *AccDeploymentData `json:"deployment,omitempty"`
-	// The invoke data for the transaction, used for `invoke` and `deploy_and_invoke` transaction types.
+	// The invoke data for the transaction, used for `invoke` and
+	// `deploy_and_invoke` transaction types.
 	// Should be `nil` for `deploy` transaction types.
 	Invoke *UserInvoke `json:"invoke,omitempty"`
 }
 
-// An enum representing the type of the transaction to be executed by the paymaster
+// An enum representing the type of the transaction to be executed
+// by the paymaster
 type UserTxnType string
 
 const (
@@ -213,20 +223,23 @@ func (feeMode *FeeModeType) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-// Specify how the transaction should be paid. Either by the user specifying a gas token or through sponsorship
+// Specify how the transaction should be paid. Either by the user
+// specifying a gas token or through sponsorship
 type FeeMode struct {
 	// The fee mode type to use for the transaction
 	Mode FeeModeType `json:"mode"`
 	// The gas token to use for the transaction. Should be omitted for `sponsored` fee mode
 	GasToken *felt.Felt `json:"gas_token,omitempty"`
-	// Relative tip priority or a custom tip value. If not provided/is `nil`, the paymaster will use the `normal` tip priority by default.
+	// Relative tip priority or a custom tip value. If not provided/is `nil`,
+	// the paymaster will use the `normal` tip priority by default.
 	Tip *TipPriority `json:"tip,omitempty"`
 }
 
 // Relative tip priority or a custom tip value.
 //
 // The user must specify either the priority or the custom tip value.
-// If both fields are omitted (or TipPriority is `nil`), the paymaster will use the `normal` tip priority by default.
+// If both fields are omitted (or TipPriority is `nil`), the paymaster will
+// use the `normal` tip priority by default.
 type TipPriority struct {
 	// The relative tip priority
 	Priority TipPriorityEnum `json:"-"`
@@ -319,7 +332,8 @@ type FeeEstimate struct {
 }
 
 // BuildTransactionResponse is the response from the `paymaster_buildTransaction` method.
-// It contains the transaction data required for the paymaster to execute, along with an estimation of the fee.
+// It contains the transaction data required for the paymaster to execute, along with
+// an estimation of the fee.
 type BuildTransactionResponse struct {
 	// The type of the transaction
 	Type UserTxnType `json:"type"`
@@ -330,7 +344,7 @@ type BuildTransactionResponse struct {
 	Parameters *UserParameters `json:"parameters"`
 	// The typed data for for `invoke` and `deploy_and_invoke` transaction types.
 	// It's `nil` for `deploy` transaction types.
-	TypedData *typedData.TypedData `json:"typed_data,omitempty"`
+	TypedData *typedata.TypedData `json:"typed_data,omitempty"`
 	// The fee estimation for the transaction
 	Fee *FeeEstimate `json:"fee"`
 }

--- a/paymaster/build_txn_test.go
+++ b/paymaster/build_txn_test.go
@@ -19,7 +19,7 @@ var STRKContractAddress, _ = internalUtils.HexToFelt(
 
 // Test the UserTxnType type
 //
-//nolint:dupl // The enum tests are similar, but with different enum values
+
 func TestUserTxnType(t *testing.T) {
 	tests.RunTestOn(t, tests.MockEnv)
 	t.Parallel()

--- a/paymaster/build_txn_test.go
+++ b/paymaster/build_txn_test.go
@@ -470,7 +470,7 @@ func TestBuildTransaction(t *testing.T) {
 				t.Context(),
 				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 				"paymaster_buildTransaction",
-				request,
+				&request,
 			).Return(nil).
 				SetArg(1, response)
 
@@ -525,7 +525,7 @@ func TestBuildTransaction(t *testing.T) {
 				t.Context(),
 				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 				"paymaster_buildTransaction",
-				request,
+				&request,
 			).Return(nil).
 				SetArg(1, response)
 
@@ -580,7 +580,7 @@ func TestBuildTransaction(t *testing.T) {
 					t.Context(),
 					gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 					"paymaster_buildTransaction",
-					request,
+					&request,
 				).Return(nil).
 					SetArg(1, response)
 

--- a/paymaster/build_txn_test.go
+++ b/paymaster/build_txn_test.go
@@ -13,7 +13,9 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-var STRKContractAddress, _ = internalUtils.HexToFelt("0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D")
+var STRKContractAddress, _ = internalUtils.HexToFelt(
+	"0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D",
+)
 
 // Test the UserTxnType type
 func TestUserTxnType(t *testing.T) {
@@ -134,16 +136,22 @@ func TestBuildTransaction(t *testing.T) {
 	)
 
 	deploymentData := &AccDeploymentData{
-		Address:             internalUtils.TestHexToFelt(t, "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220"),
+		Address: internalUtils.TestHexToFelt(
+			t,
+			"0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220",
+		),
 		ClassHash:           classHash,
-		Salt:                internalUtils.RANDOM_FELT,
-		ConstructorCalldata: []*felt.Felt{internalUtils.RANDOM_FELT},
-		SignatureData:       []*felt.Felt{internalUtils.RANDOM_FELT},
+		Salt:                internalUtils.DeadBeef,
+		ConstructorCalldata: []*felt.Felt{internalUtils.DeadBeef},
+		SignatureData:       []*felt.Felt{internalUtils.DeadBeef},
 		Version:             2,
 	}
 
 	// *** setup for invoke type transactions
-	accountAddress := internalUtils.TestHexToFelt(t, "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e")
+	accountAddress := internalUtils.TestHexToFelt(
+		t,
+		"0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+	)
 	transferAmount, _ := internalUtils.HexToU256Felt("0xfff")
 
 	invokeData := &UserInvoke{
@@ -156,7 +164,10 @@ func TestBuildTransaction(t *testing.T) {
 			},
 			{
 				// same ERC20 contract as in examples/simpleInvoke
-				To:       internalUtils.TestHexToFelt(t, "0x0669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54"),
+				To: internalUtils.TestHexToFelt(
+					t,
+					"0x0669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+				),
 				Selector: internalUtils.GetSelectorFromNameFelt("mint"),
 				Calldata: []*felt.Felt{new(felt.Felt).SetUint64(10000), &felt.Zero},
 			},
@@ -213,7 +224,10 @@ func TestBuildTransaction(t *testing.T) {
 				}
 
 				_, err := pm.BuildTransaction(context.Background(), &request)
-				require.Error(t, err) // it seems that the default fee mode is not supported for the 'deploy' transaction type
+				require.Error(
+					t,
+					err,
+				) // it seems that the default fee mode is not supported for the 'deploy' transaction type
 			})
 		})
 
@@ -452,57 +466,60 @@ func TestBuildTransaction(t *testing.T) {
 			assert.JSONEq(t, string(expectedResp), string(rawResp))
 		})
 
-		t.Run("deploy-and-invoke transaction type - sponsored fee mode with slow tip priority", func(t *testing.T) {
-			t.Parallel()
-			// *** build request
-			request := BuildTransactionRequest{
-				Transaction: &UserTransaction{
-					Type:       UserTxnDeployAndInvoke,
-					Deployment: deploymentData,
-					Invoke:     invokeData,
-				},
-				Parameters: &UserParameters{
-					Version: UserParamV1,
-					FeeMode: FeeMode{
-						Mode: FeeModeSponsored,
-						Tip: &TipPriority{
-							Priority: TipPrioritySlow,
+		t.Run(
+			"deploy-and-invoke transaction type - sponsored fee mode with slow tip priority",
+			func(t *testing.T) {
+				t.Parallel()
+				// *** build request
+				request := BuildTransactionRequest{
+					Transaction: &UserTransaction{
+						Type:       UserTxnDeployAndInvoke,
+						Deployment: deploymentData,
+						Invoke:     invokeData,
+					},
+					Parameters: &UserParameters{
+						Version: UserParamV1,
+						FeeMode: FeeMode{
+							Mode: FeeModeSponsored,
+							Tip: &TipPriority{
+								Priority: TipPrioritySlow,
+							},
 						},
 					},
-				},
-			}
+				}
 
-			// *** assert the request marshalled is equal to the expected request
-			expectedReqs := *internalUtils.TestUnmarshalJSONFileToType[[]json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-request.json", "params")
-			expectedReq := expectedReqs[0]
+				// *** assert the request marshalled is equal to the expected request
+				expectedReqs := *internalUtils.TestUnmarshalJSONFileToType[[]json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-request.json", "params")
+				expectedReq := expectedReqs[0]
 
-			rawReq, err := json.Marshal(request)
-			require.NoError(t, err)
+				rawReq, err := json.Marshal(request)
+				require.NoError(t, err)
 
-			assert.JSONEq(t, string(expectedReq), string(rawReq))
+				assert.JSONEq(t, string(expectedReq), string(rawReq))
 
-			// *** assert the response marshalled is equal to the expected response
-			expectedResp := *internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-response.json", "result")
+				// *** assert the response marshalled is equal to the expected response
+				expectedResp := *internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-response.json", "result")
 
-			var response BuildTransactionResponse
-			err = json.Unmarshal(expectedResp, &response)
-			require.NoError(t, err)
+				var response BuildTransactionResponse
+				err = json.Unmarshal(expectedResp, &response)
+				require.NoError(t, err)
 
-			pm := SetupMockPaymaster(t)
-			pm.c.EXPECT().CallContextWithSliceArgs(
-				context.Background(),
-				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
-				"paymaster_buildTransaction",
-				&request,
-			).Return(nil).
-				SetArg(1, response)
+				pm := SetupMockPaymaster(t)
+				pm.c.EXPECT().CallContextWithSliceArgs(
+					context.Background(),
+					gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
+					"paymaster_buildTransaction",
+					&request,
+				).Return(nil).
+					SetArg(1, response)
 
-			resp, err := pm.BuildTransaction(context.Background(), &request)
-			require.NoError(t, err)
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
 
-			rawResp, err := json.Marshal(resp)
-			require.NoError(t, err)
-			assert.JSONEq(t, string(expectedResp), string(rawResp))
-		})
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(expectedResp), string(rawResp))
+			},
+		)
 	})
 }

--- a/paymaster/build_txn_test.go
+++ b/paymaster/build_txn_test.go
@@ -1,7 +1,6 @@
 package paymaster
 
 import (
-	"context"
 	"encoding/json"
 	"testing"
 
@@ -273,7 +272,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 
 				rawResp, err := json.Marshal(resp)
@@ -295,7 +294,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				_, err := pm.BuildTransaction(context.Background(), request)
+				_, err := pm.BuildTransaction(t.Context(), &request)
 				require.Error(
 					t,
 					err,
@@ -326,7 +325,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 				// The default tip priority is normal
 				assert.Equal(t, TipPriorityNormal, resp.Parameters.FeeMode.Tip.Priority)
@@ -353,7 +352,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 
 				assert.Equal(t, customTip, *resp.Parameters.FeeMode.Tip.Custom)
@@ -392,7 +391,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 
 				assert.Equal(t, TipPrioritySlow, resp.Parameters.FeeMode.Tip.Priority)
@@ -418,7 +417,7 @@ func TestBuildTransaction(t *testing.T) {
 					},
 				}
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 
 				assert.Equal(t, TipPriorityFast, resp.Parameters.FeeMode.Tip.Priority)
@@ -468,14 +467,14 @@ func TestBuildTransaction(t *testing.T) {
 
 			pm := SetupMockPaymaster(t)
 			pm.c.EXPECT().CallContextWithSliceArgs(
-				context.Background(),
+				t.Context(),
 				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 				"paymaster_buildTransaction",
 				request,
 			).Return(nil).
 				SetArg(1, response)
 
-			resp, err := pm.BuildTransaction(context.Background(), request)
+			resp, err := pm.BuildTransaction(t.Context(), &request)
 			require.NoError(t, err)
 
 			rawResp, err := json.Marshal(resp)
@@ -523,14 +522,14 @@ func TestBuildTransaction(t *testing.T) {
 
 			pm := SetupMockPaymaster(t)
 			pm.c.EXPECT().CallContextWithSliceArgs(
-				context.Background(),
+				t.Context(),
 				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 				"paymaster_buildTransaction",
 				request,
 			).Return(nil).
 				SetArg(1, response)
 
-			resp, err := pm.BuildTransaction(context.Background(), request)
+			resp, err := pm.BuildTransaction(t.Context(), &request)
 			require.NoError(t, err)
 
 			rawResp, err := json.Marshal(resp)
@@ -578,14 +577,14 @@ func TestBuildTransaction(t *testing.T) {
 
 				pm := SetupMockPaymaster(t)
 				pm.c.EXPECT().CallContextWithSliceArgs(
-					context.Background(),
+					t.Context(),
 					gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
 					"paymaster_buildTransaction",
 					request,
 				).Return(nil).
 					SetArg(1, response)
 
-				resp, err := pm.BuildTransaction(context.Background(), request)
+				resp, err := pm.BuildTransaction(t.Context(), &request)
 				require.NoError(t, err)
 
 				rawResp, err := json.Marshal(resp)

--- a/paymaster/build_txn_test.go
+++ b/paymaster/build_txn_test.go
@@ -1,0 +1,508 @@
+package paymaster
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/internal/tests"
+	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+var STRKContractAddress, _ = internalUtils.HexToFelt("0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D")
+
+// Test the UserTxnType type
+func TestUserTxnType(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+	t.Parallel()
+
+	type testCase struct {
+		Input         string
+		Expected      UserTxnType
+		ErrorExpected bool
+	}
+
+	testCases := []testCase{
+		{
+			Input:         `"deploy"`,
+			Expected:      UserTxnDeploy,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"invoke"`,
+			Expected:      UserTxnInvoke,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"deploy_and_invoke"`,
+			Expected:      UserTxnDeployAndInvoke,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"unknown"`,
+			ErrorExpected: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Input, func(t *testing.T) {
+			t.Parallel()
+			CompareEnumsHelper(t, test.Input, test.Expected, test.ErrorExpected)
+		})
+	}
+}
+
+// Test the FeeModeType type
+func TestFeeModeType(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+	t.Parallel()
+
+	type testCase struct {
+		Input         string
+		Expected      FeeModeType
+		ErrorExpected bool
+	}
+
+	testCases := []testCase{
+		{
+			Input:         `"default"`,
+			Expected:      FeeModeDefault,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"sponsored"`,
+			Expected:      FeeModeSponsored,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"unknown"`,
+			ErrorExpected: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Input, func(t *testing.T) {
+			t.Parallel()
+			CompareEnumsHelper(t, test.Input, test.Expected, test.ErrorExpected)
+		})
+	}
+}
+
+// Test the UserParamVersion type
+func TestUserParamVersion(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+	t.Parallel()
+
+	type testCase struct {
+		Input         string
+		Expected      UserParamVersion
+		ErrorExpected bool
+	}
+
+	testCases := []testCase{
+		{
+			Input:         `"0x1"`,
+			Expected:      UserParamV1,
+			ErrorExpected: false,
+		},
+		{
+			Input:         `"0x2"`,
+			ErrorExpected: true,
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.Input, func(t *testing.T) {
+			t.Parallel()
+			CompareEnumsHelper(t, test.Input, test.Expected, test.ErrorExpected)
+		})
+	}
+}
+
+// Test the BuildTransaction method with different transaction types and fee modes.
+func TestBuildTransaction(t *testing.T) {
+	t.Parallel()
+
+	// *** setup for deploy type transactions
+	classHash := internalUtils.TestHexToFelt(
+		t,
+		"0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f", // OZ account class hash
+	)
+
+	deploymentData := &AccDeploymentData{
+		Address:             internalUtils.TestHexToFelt(t, "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220"),
+		ClassHash:           classHash,
+		Salt:                internalUtils.RANDOM_FELT,
+		ConstructorCalldata: []*felt.Felt{internalUtils.RANDOM_FELT},
+		SignatureData:       []*felt.Felt{internalUtils.RANDOM_FELT},
+		Version:             2,
+	}
+
+	// *** setup for invoke type transactions
+	accountAddress := internalUtils.TestHexToFelt(t, "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e")
+	transferAmount, _ := internalUtils.HexToU256Felt("0xfff")
+
+	invokeData := &UserInvoke{
+		UserAddress: accountAddress,
+		Calls: []Call{
+			{
+				To:       STRKContractAddress,
+				Selector: internalUtils.GetSelectorFromNameFelt("transfer"),
+				Calldata: append([]*felt.Felt{accountAddress}, transferAmount...),
+			},
+			{
+				// same ERC20 contract as in examples/simpleInvoke
+				To:       internalUtils.TestHexToFelt(t, "0x0669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54"),
+				Selector: internalUtils.GetSelectorFromNameFelt("mint"),
+				Calldata: []*felt.Felt{new(felt.Felt).SetUint64(10000), &felt.Zero},
+			},
+		},
+	}
+
+	t.Run("integration", func(t *testing.T) {
+		t.Parallel()
+		tests.RunTestOn(t, tests.IntegrationEnv)
+
+		t.Run("deploy transaction type", func(t *testing.T) {
+			t.Parallel()
+			// *** build request
+			reqBody := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:       UserTxnDeploy,
+					Deployment: deploymentData,
+				},
+				Parameters: nil,
+			}
+
+			t.Run("sponsored fee mode", func(t *testing.T) {
+				t.Parallel()
+				pm, spy := SetupPaymaster(t)
+
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode: FeeModeSponsored,
+					},
+				}
+
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
+
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(spy.LastResponse()), string(rawResp))
+			})
+
+			t.Run("default fee mode", func(t *testing.T) {
+				t.Parallel()
+				pm, _ := SetupPaymaster(t)
+
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode:     FeeModeDefault,
+						GasToken: STRKContractAddress,
+						Tip:      nil,
+					},
+				}
+
+				_, err := pm.BuildTransaction(context.Background(), &request)
+				require.Error(t, err) // it seems that the default fee mode is not supported for the 'deploy' transaction type
+			})
+		})
+
+		t.Run("invoke transaction type", func(t *testing.T) {
+			t.Parallel()
+
+			reqBody := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:   UserTxnInvoke,
+					Invoke: invokeData,
+				},
+				Parameters: nil,
+			}
+
+			t.Run("sponsored fee mode - with nil tip", func(t *testing.T) {
+				t.Parallel()
+				pm, spy := SetupPaymaster(t)
+
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode: FeeModeSponsored,
+					},
+				}
+
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
+				// The default tip priority is normal
+				assert.Equal(t, TipPriorityNormal, resp.Parameters.FeeMode.Tip.Priority)
+
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(spy.LastResponse()), string(rawResp))
+			})
+
+			t.Run("default fee mode - with custom tip", func(t *testing.T) {
+				t.Parallel()
+				pm, spy := SetupPaymaster(t)
+
+				customTip := uint64(1000)
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode:     FeeModeDefault,
+						GasToken: STRKContractAddress,
+						Tip: &TipPriority{
+							Custom: &customTip,
+						},
+					},
+				}
+
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
+
+				assert.Equal(t, customTip, *resp.Parameters.FeeMode.Tip.Custom)
+
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(spy.LastResponse()), string(rawResp))
+			})
+		})
+
+		t.Run("deploy-and-invoke transaction type", func(t *testing.T) {
+			t.Parallel()
+
+			reqBody := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:   UserTxnDeployAndInvoke,
+					Invoke: invokeData,
+				},
+				Parameters: nil,
+			}
+			reqBody.Transaction.Deployment = deploymentData
+			reqBody.Transaction.Invoke = invokeData
+
+			t.Run("sponsored fee mode - with slow tip", func(t *testing.T) {
+				t.Parallel()
+				pm, spy := SetupPaymaster(t)
+
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode: FeeModeSponsored,
+						Tip: &TipPriority{
+							Priority: TipPrioritySlow,
+						},
+					},
+				}
+
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
+
+				assert.Equal(t, TipPrioritySlow, resp.Parameters.FeeMode.Tip.Priority)
+
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(spy.LastResponse()), string(rawResp))
+			})
+
+			t.Run("default fee mode - with fast tip", func(t *testing.T) {
+				t.Parallel()
+				pm, spy := SetupPaymaster(t)
+
+				request := reqBody
+				request.Parameters = &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode:     FeeModeDefault,
+						GasToken: STRKContractAddress,
+						Tip: &TipPriority{
+							Priority: TipPriorityFast,
+						},
+					},
+				}
+
+				resp, err := pm.BuildTransaction(context.Background(), &request)
+				require.NoError(t, err)
+
+				assert.Equal(t, TipPriorityFast, resp.Parameters.FeeMode.Tip.Priority)
+
+				rawResp, err := json.Marshal(resp)
+				require.NoError(t, err)
+				assert.JSONEq(t, string(spy.LastResponse()), string(rawResp))
+			})
+		})
+	})
+
+	t.Run("mock", func(t *testing.T) {
+		t.Parallel()
+		tests.RunTestOn(t, tests.MockEnv)
+
+		t.Run("deploy transaction type - sponsored fee mode", func(t *testing.T) {
+			t.Parallel()
+			// *** build request
+			request := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:       UserTxnDeploy,
+					Deployment: deploymentData,
+				},
+				Parameters: &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode: FeeModeSponsored,
+					},
+				},
+			}
+
+			// *** assert the request marshalled is equal to the expected request
+			expectedReqs := *internalUtils.TestUnmarshalJSONFileToType[[]json.RawMessage](t, "testdata/build_txn/deploy-request.json", "params")
+			expectedReq := expectedReqs[0]
+
+			rawReq, err := json.Marshal(request)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expectedReq), string(rawReq))
+
+			// *** assert the response marshalled is equal to the expected response
+			expectedResp := *internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](t, "testdata/build_txn/deploy-response.json", "result")
+
+			var response BuildTransactionResponse
+			err = json.Unmarshal(expectedResp, &response)
+			require.NoError(t, err)
+
+			pm := SetupMockPaymaster(t)
+			pm.c.EXPECT().CallContextWithSliceArgs(
+				context.Background(),
+				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
+				"paymaster_buildTransaction",
+				&request,
+			).Return(nil).
+				SetArg(1, response)
+
+			resp, err := pm.BuildTransaction(context.Background(), &request)
+			require.NoError(t, err)
+
+			rawResp, err := json.Marshal(resp)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expectedResp), string(rawResp))
+		})
+
+		t.Run("invoke transaction type - default fee mode with custom tip", func(t *testing.T) {
+			t.Parallel()
+			// *** build request
+			customTip := uint64(1000)
+
+			request := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:   UserTxnInvoke,
+					Invoke: invokeData,
+				},
+				Parameters: &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode:     FeeModeDefault,
+						GasToken: STRKContractAddress,
+						Tip: &TipPriority{
+							Custom: &customTip,
+						},
+					},
+				},
+			}
+
+			// *** assert the request marshalled is equal to the expected request
+			expectedReqs := *internalUtils.TestUnmarshalJSONFileToType[[]json.RawMessage](t, "testdata/build_txn/invoke-request.json", "params")
+			expectedReq := expectedReqs[0]
+
+			rawReq, err := json.Marshal(request)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expectedReq), string(rawReq))
+
+			// *** assert the response marshalled is equal to the expected response
+			expectedResp := *internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](t, "testdata/build_txn/invoke-response.json", "result")
+
+			var response BuildTransactionResponse
+			err = json.Unmarshal(expectedResp, &response)
+			require.NoError(t, err)
+
+			pm := SetupMockPaymaster(t)
+			pm.c.EXPECT().CallContextWithSliceArgs(
+				context.Background(),
+				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
+				"paymaster_buildTransaction",
+				&request,
+			).Return(nil).
+				SetArg(1, response)
+
+			resp, err := pm.BuildTransaction(context.Background(), &request)
+			require.NoError(t, err)
+
+			rawResp, err := json.Marshal(resp)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expectedResp), string(rawResp))
+		})
+
+		t.Run("deploy-and-invoke transaction type - sponsored fee mode with slow tip priority", func(t *testing.T) {
+			t.Parallel()
+			// *** build request
+			request := BuildTransactionRequest{
+				Transaction: &UserTransaction{
+					Type:       UserTxnDeployAndInvoke,
+					Deployment: deploymentData,
+					Invoke:     invokeData,
+				},
+				Parameters: &UserParameters{
+					Version: UserParamV1,
+					FeeMode: FeeMode{
+						Mode: FeeModeSponsored,
+						Tip: &TipPriority{
+							Priority: TipPrioritySlow,
+						},
+					},
+				},
+			}
+
+			// *** assert the request marshalled is equal to the expected request
+			expectedReqs := *internalUtils.TestUnmarshalJSONFileToType[[]json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-request.json", "params")
+			expectedReq := expectedReqs[0]
+
+			rawReq, err := json.Marshal(request)
+			require.NoError(t, err)
+
+			assert.JSONEq(t, string(expectedReq), string(rawReq))
+
+			// *** assert the response marshalled is equal to the expected response
+			expectedResp := *internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](t, "testdata/build_txn/deploy_and_invoke-response.json", "result")
+
+			var response BuildTransactionResponse
+			err = json.Unmarshal(expectedResp, &response)
+			require.NoError(t, err)
+
+			pm := SetupMockPaymaster(t)
+			pm.c.EXPECT().CallContextWithSliceArgs(
+				context.Background(),
+				gomock.AssignableToTypeOf(new(BuildTransactionResponse)),
+				"paymaster_buildTransaction",
+				&request,
+			).Return(nil).
+				SetArg(1, response)
+
+			resp, err := pm.BuildTransaction(context.Background(), &request)
+			require.NoError(t, err)
+
+			rawResp, err := json.Marshal(resp)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(expectedResp), string(rawResp))
+		})
+	})
+}

--- a/paymaster/main_test.go
+++ b/paymaster/main_test.go
@@ -5,10 +5,8 @@ import (
 	"os"
 	"testing"
 
-	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/client"
 	"github.com/NethermindEth/starknet.go/internal/tests"
-	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
 	"github.com/NethermindEth/starknet.go/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -58,22 +56,6 @@ func SetupMockPaymaster(t *testing.T) *MockPaymaster {
 	}
 
 	return mpm
-}
-
-// GetStrkAccountData returns the STRK account data from the environment variables.
-// This is used for integration tests, where we need a real testnet account with STRK tokens.
-func GetStrkAccountData(t *testing.T) (privKey, pubKey, accountAddress *felt.Felt) {
-	t.Helper()
-
-	strkPrivKey := os.Getenv("STARKNET_PRIVATE_KEY")
-	strkPubKey := os.Getenv("STARKNET_PUBLIC_KEY")
-	strkAccountAddress := os.Getenv("STARKNET_ACCOUNT_ADDRESS")
-
-	privKey = internalUtils.TestHexToFelt(t, strkPrivKey)
-	pubKey = internalUtils.TestHexToFelt(t, strkPubKey)
-	accountAddress = internalUtils.TestHexToFelt(t, strkAccountAddress)
-
-	return privKey, pubKey, accountAddress
 }
 
 // CompareEnumsHelper compares an enum type with the expected value and error expected.

--- a/paymaster/main_test.go
+++ b/paymaster/main_test.go
@@ -1,6 +1,7 @@
 package paymaster
 
 import (
+	"context"
 	"encoding/json"
 	"os"
 	"testing"
@@ -36,7 +37,7 @@ func SetupPaymaster(t *testing.T, debug ...bool) (*Paymaster, tests.Spyer) {
 	require.NotEmpty(t, apiKey, "AVNU_API_KEY is not set")
 	apiHeader := client.WithHeader("x-paymaster-api-key", apiKey)
 
-	pm, err := New(avnuPaymasterURL, apiHeader)
+	pm, err := New(context.Background(), avnuPaymasterURL, apiHeader)
 	require.NoError(t, err, "failed to create paymaster client")
 
 	spy := tests.NewJSONRPCSpy(pm.c, debug...)

--- a/paymaster/paymaster.go
+++ b/paymaster/paymaster.go
@@ -55,7 +55,7 @@ type callCloser interface {
 // Returns:
 //   - *Paymaster: A new paymaster client instance
 //   - error: An error if the client creation fails
-func New(url string, options ...client.ClientOption) (*Paymaster, error) {
+func New(ctx context.Context, url string, options ...client.ClientOption) (*Paymaster, error) {
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
 		return nil, err
@@ -63,7 +63,7 @@ func New(url string, options ...client.ClientOption) (*Paymaster, error) {
 	httpClient := &http.Client{Jar: jar} //nolint:exhaustruct // Only the Jar field is used.
 	// prepend the custom client to allow users to override
 	options = append([]client.ClientOption{client.WithHTTPClient(httpClient)}, options...)
-	c, err := client.DialOptions(context.Background(), url, options...)
+	c, err := client.DialOptions(ctx, url, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/paymaster/paymaster.go
+++ b/paymaster/paymaster.go
@@ -22,6 +22,7 @@ type Paymaster struct {
 //
 //nolint:lll // The link would be unclickable if we break the line.
 type paymasterInterface interface {
+	BuildTransaction(ctx context.Context, request *BuildTransactionRequest) (*BuildTransactionResponse, error)
 	IsAvailable(ctx context.Context) (bool, error)
 	// More methods coming...
 }

--- a/paymaster/paymaster.go
+++ b/paymaster/paymaster.go
@@ -24,7 +24,7 @@ type Paymaster struct {
 type paymasterInterface interface {
 	BuildTransaction(
 		ctx context.Context,
-		request BuildTransactionRequest,
+		request *BuildTransactionRequest,
 	) (BuildTransactionResponse, error)
 	IsAvailable(ctx context.Context) (bool, error)
 	// More methods coming...

--- a/paymaster/paymaster.go
+++ b/paymaster/paymaster.go
@@ -22,7 +22,10 @@ type Paymaster struct {
 //
 //nolint:lll // The link would be unclickable if we break the line.
 type paymasterInterface interface {
-	BuildTransaction(ctx context.Context, request *BuildTransactionRequest) (*BuildTransactionResponse, error)
+	BuildTransaction(
+		ctx context.Context,
+		request *BuildTransactionRequest,
+	) (*BuildTransactionResponse, error)
 	IsAvailable(ctx context.Context) (bool, error)
 	// More methods coming...
 }

--- a/paymaster/paymaster.go
+++ b/paymaster/paymaster.go
@@ -24,8 +24,8 @@ type Paymaster struct {
 type paymasterInterface interface {
 	BuildTransaction(
 		ctx context.Context,
-		request *BuildTransactionRequest,
-	) (*BuildTransactionResponse, error)
+		request BuildTransactionRequest,
+	) (BuildTransactionResponse, error)
 	IsAvailable(ctx context.Context) (bool, error)
 	// More methods coming...
 }

--- a/paymaster/testdata/build_txn/deploy-request.json
+++ b/paymaster/testdata/build_txn/deploy-request.json
@@ -1,0 +1,31 @@
+{
+	"jsonrpc":"2.0",
+	"method":"paymaster_buildTransaction",
+	"params":[
+		{
+   "transaction":{
+      "type":"deploy",
+      "deployment":{
+         "address": "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220",
+         "class_hash":"0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+         "salt":"0xdeadbeef",
+         "calldata":[
+            "0xdeadbeef"
+         ],
+				 "sigdata":[
+            "0xdeadbeef"
+         ],
+         "version":2
+      }
+   },
+   "parameters":{
+      "version":"0x1",
+      "fee_mode":{
+			 	"mode":"sponsored"
+      },
+		 "time_bounds": null
+   }
+}
+	],
+	"id":1
+}

--- a/paymaster/testdata/build_txn/deploy-request.json
+++ b/paymaster/testdata/build_txn/deploy-request.json
@@ -15,7 +15,7 @@
 				 "sigdata":[
             "0xdeadbeef"
          ],
-         "version":2
+         "version": 1
       }
    },
    "parameters":{

--- a/paymaster/testdata/build_txn/deploy-response.json
+++ b/paymaster/testdata/build_txn/deploy-response.json
@@ -1,0 +1,34 @@
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"type": "deploy",
+		"deployment": {
+			"address": "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220",
+			"class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+			"salt": "0xdeadbeef",
+			"calldata": [
+				"0xdeadbeef"
+			],
+			"sigdata": [
+				"0xdeadbeef"
+			],
+			"version": 2
+		},
+		"parameters": {
+			"version": "0x1",
+			"fee_mode": {
+				"mode": "sponsored",
+				"tip": "normal"
+			},
+			"time_bounds": null
+		},
+		"fee": {
+			"gas_token_price_in_strk": "0xde0b6b3a7640000",
+			"estimated_fee_in_strk": "0xd0867e191fcc0",
+			"estimated_fee_in_gas_token": "0xd0867e191fcc0",
+			"suggested_max_fee_in_strk": "0x4e326f496bec80",
+			"suggested_max_fee_in_gas_token": "0x4e326f496bec80"
+		}
+	}
+}

--- a/paymaster/testdata/build_txn/deploy-response.json
+++ b/paymaster/testdata/build_txn/deploy-response.json
@@ -13,7 +13,7 @@
 			"sigdata": [
 				"0xdeadbeef"
 			],
-			"version": 2
+			"version": 1
 		},
 		"parameters": {
 			"version": "0x1",

--- a/paymaster/testdata/build_txn/deploy_and_invoke-request.json
+++ b/paymaster/testdata/build_txn/deploy_and_invoke-request.json
@@ -15,7 +15,7 @@
           "sigdata": [
             "0xdeadbeef"
           ],
-          "version": 2
+          "version": 1
         },
         "invoke": {
           "user_address": "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",

--- a/paymaster/testdata/build_txn/deploy_and_invoke-request.json
+++ b/paymaster/testdata/build_txn/deploy_and_invoke-request.json
@@ -1,0 +1,54 @@
+{
+  "jsonrpc": "2.0",
+  "method": "paymaster_buildTransaction",
+  "params": [
+    {
+      "transaction": {
+        "type": "deploy_and_invoke",
+        "deployment": {
+          "address": "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220",
+          "class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+          "salt": "0xdeadbeef",
+          "calldata": [
+            "0xdeadbeef"
+          ],
+          "sigdata": [
+            "0xdeadbeef"
+          ],
+          "version": 2
+        },
+        "invoke": {
+          "user_address": "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+          "calls": [
+            {
+              "to": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+              "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+              "calldata": [
+                "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+                "0xfff",
+                "0x0"
+              ]
+            },
+            {
+              "to": "0x669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+              "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+              "calldata": [
+                "0x2710",
+                "0x0"
+              ]
+            }
+          ]
+        }
+      },
+      "parameters": {
+        "version": "0x1",
+        "fee_mode": {
+          "mode": "sponsored",
+          "tip": "slow"
+        },
+        "time_bounds": null
+      }
+    }
+  ],
+  "id": 1
+}

--- a/paymaster/testdata/build_txn/deploy_and_invoke-response.json
+++ b/paymaster/testdata/build_txn/deploy_and_invoke-response.json
@@ -1,0 +1,124 @@
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"type": "deploy_and_invoke",
+		"deployment": {
+			"address": "0x736b7c3fac1586518b55cccac1f675ca1bd0570d7354e2f2d23a0975a31f220",
+			"class_hash": "0x61dac032f228abef9c6626f995015233097ae253a7f72d68552db02f2971b8f",
+			"salt": "0xdeadbeef",
+			"calldata": [
+				"0xdeadbeef"
+			],
+			"sigdata": [
+				"0xdeadbeef"
+			],
+			"version": 2
+		},
+		"typed_data": {
+			"types": {
+				"StarknetDomain": [
+					{
+						"name": "name",
+						"type": "shortstring"
+					},
+					{
+						"name": "version",
+						"type": "shortstring"
+					},
+					{
+						"name": "chainId",
+						"type": "shortstring"
+					},
+					{
+						"name": "revision",
+						"type": "shortstring"
+					}
+				],
+				"OutsideExecution": [
+					{
+						"name": "Caller",
+						"type": "ContractAddress"
+					},
+					{
+						"name": "Nonce",
+						"type": "felt"
+					},
+					{
+						"name": "Execute After",
+						"type": "u128"
+					},
+					{
+						"name": "Execute Before",
+						"type": "u128"
+					},
+					{
+						"name": "Calls",
+						"type": "Call*"
+					}
+				],
+				"Call": [
+					{
+						"name": "To",
+						"type": "ContractAddress"
+					},
+					{
+						"name": "Selector",
+						"type": "selector"
+					},
+					{
+						"name": "Calldata",
+						"type": "felt*"
+					}
+				]
+			},
+			"domain": {
+				"name": "Account.execute_from_outside",
+				"version": "2",
+				"chainId": "SN_SEPOLIA",
+				"revision": "1"
+			},
+			"primaryType": "OutsideExecution",
+			"message": {
+				"Caller": "0x75a180e18e56da1b1cae181c92a288f586f5fe22c18df21cf97886f1e4b316c",
+				"Nonce": "0xc994e1f239c9edadcf4fc39693e03b7c",
+				"Execute After": "0x1",
+				"Execute Before": "0x68cb10b3",
+				"Calls": [
+					{
+						"To": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+						"Selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+						"Calldata": [
+							"0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+							"0xfff",
+							"0x0"
+						]
+					},
+					{
+						"To": "0x669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+						"Selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+						"Calldata": [
+							"0x2710",
+							"0x0"
+						]
+					}
+				]
+			}
+		},
+		"parameters": {
+			"version": "0x1",
+			"fee_mode": {
+				"mode": "sponsored",
+				"tip": "slow"
+			},
+			"time_bounds": null
+		},
+		"fee": {
+			"gas_token_price_in_strk": "0xde0b6b3a7640000",
+			"estimated_fee_in_strk": "0x1bb9c13f50bbc0",
+			"estimated_fee_in_gas_token": "0x1bb9c13f50bbc0",
+			"suggested_max_fee_in_strk": "0xa65a877be46680",
+			"suggested_max_fee_in_gas_token": "0xa65a877be46680"
+		}
+	}
+}

--- a/paymaster/testdata/build_txn/deploy_and_invoke-response.json
+++ b/paymaster/testdata/build_txn/deploy_and_invoke-response.json
@@ -13,7 +13,7 @@
 			"sigdata": [
 				"0xdeadbeef"
 			],
-			"version": 2
+			"version": 1
 		},
 		"typed_data": {
 			"types": {

--- a/paymaster/testdata/build_txn/invoke-request.json
+++ b/paymaster/testdata/build_txn/invoke-request.json
@@ -1,0 +1,45 @@
+{
+  "jsonrpc": "2.0",
+  "method": "paymaster_buildTransaction",
+  "params": [
+    {
+      "transaction": {
+        "type": "invoke",
+        "invoke": {
+          "user_address": "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+          "calls": [
+            {
+              "to": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+              "selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+              "calldata": [
+                "0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+                "0xfff",
+                "0x0"
+              ]
+            },
+            {
+              "to": "0x669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+              "selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+              "calldata": [
+                "0x2710",
+                "0x0"
+              ]
+            }
+          ]
+        }
+      },
+      "parameters": {
+        "version": "0x1",
+        "fee_mode": {
+          "mode": "default",
+          "gas_token": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+          "tip": {
+            "custom": 1000
+          }
+        },
+        "time_bounds": null
+      }
+    }
+  ],
+  "id": 1
+}

--- a/paymaster/testdata/build_txn/invoke-response.json
+++ b/paymaster/testdata/build_txn/invoke-response.json
@@ -1,0 +1,124 @@
+{
+	"jsonrpc": "2.0",
+	"id": 1,
+	"result": {
+		"type": "invoke",
+		"typed_data": {
+			"types": {
+				"StarknetDomain": [
+					{
+						"name": "name",
+						"type": "shortstring"
+					},
+					{
+						"name": "version",
+						"type": "shortstring"
+					},
+					{
+						"name": "chainId",
+						"type": "shortstring"
+					},
+					{
+						"name": "revision",
+						"type": "shortstring"
+					}
+				],
+				"OutsideExecution": [
+					{
+						"name": "Caller",
+						"type": "ContractAddress"
+					},
+					{
+						"name": "Nonce",
+						"type": "felt"
+					},
+					{
+						"name": "Execute After",
+						"type": "u128"
+					},
+					{
+						"name": "Execute Before",
+						"type": "u128"
+					},
+					{
+						"name": "Calls",
+						"type": "Call*"
+					}
+				],
+				"Call": [
+					{
+						"name": "To",
+						"type": "ContractAddress"
+					},
+					{
+						"name": "Selector",
+						"type": "selector"
+					},
+					{
+						"name": "Calldata",
+						"type": "felt*"
+					}
+				]
+			},
+			"domain": {
+				"name": "Account.execute_from_outside",
+				"version": "2",
+				"chainId": "SN_SEPOLIA",
+				"revision": "1"
+			},
+			"primaryType": "OutsideExecution",
+			"message": {
+				"Caller": "0x75a180e18e56da1b1cae181c92a288f586f5fe22c18df21cf97886f1e4b316c",
+				"Nonce": "0x7bde5b6d5ffaa858a445a4ebad13786",
+				"Execute After": "0x1",
+				"Execute Before": "0x68cb0db5",
+				"Calls": [
+					{
+						"To": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+						"Selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+						"Calldata": [
+							"0x5c74db20fa8f151bfd3a7a462cf2e8d4578a88aa4bd7a1746955201c48d8e5e",
+							"0xfff",
+							"0x0"
+						]
+					},
+					{
+						"To": "0x669e24364ce0ae7ec2864fb03eedbe60cfbc9d1c74438d10fa4b86552907d54",
+						"Selector": "0x2f0b3c5710379609eb5495f1ecd348cb28167711b73609fe565a72734550354",
+						"Calldata": [
+							"0x2710",
+							"0x0"
+						]
+					},
+					{
+						"To": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+						"Selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+						"Calldata": [
+							"0x75a180e18e56da1b1cae181c92a288f586f5fe22c18df21cf97886f1e4b316c",
+							"0x6bcd6cebb3e040",
+							"0x0"
+						]
+					}
+				]
+			}
+		},
+		"parameters": {
+			"version": "0x1",
+			"fee_mode": {
+				"mode": "default",
+				"gas_token": "0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+				"tip": {
+					"custom": 1000
+				}
+			},
+			"time_bounds": null
+		},
+		"fee": {
+			"gas_token_price_in_strk": "0xde0b6b3a7640000",
+			"estimated_fee_in_strk": "0x11f7922748a560",
+			"estimated_fee_in_gas_token": "0x11f7922748a560",
+			"suggested_max_fee_in_strk": "0x6bcd6cebb3e040",
+			"suggested_max_fee_in_gas_token": "0x6bcd6cebb3e040"
+		}
+	}
+}


### PR DESCRIPTION
Part 2 of the effort to break down the Paymaster [PR](https://github.com/NethermindEth/starknet.go/pull/768) for better review.

This PR:
- implement the `paymaster_buildTransaction` method
- new test helpers