### PR TITLE
Thiagodeev/remove-braavos-warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - The internal `tryUnwrapToRPCErr` func of the `rpc` pkg was renamed to `UnwrapToRPCErr` and moved to the new package.
   - The `Err` function now have a specific case for the `InternalError` code.
 
+### Removed
+- Braavos warning when instantiating a new `account.Account` instance.
+The issue was fixed by starkware in Starknet v0.14.0.
+
 ### Fixed
 - The `typedData.TypedData` was not being marshaled exactly as it is in the original JSON. Now, the original JSON is preserved,
   so the output of `TypedData.MarshalJSON()` is exactly as the original JSON.

--- a/account/account.go
+++ b/account/account.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"slices"
 	"time"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -15,9 +14,6 @@ import (
 var (
 	ErrTxnTypeUnSupported    = errors.New("unsupported transaction type")
 	ErrTxnVersionUnSupported = errors.New("unsupported transaction version")
-
-	//nolint:lll // The line break would be outputted in the warning message
-	BraavosWarningMessage = `WARNING: Currently, Braavos accounts are incompatible with transactions sent via RPC 0.8.0. Ref: https://community.starknet.io/t/starknet-devtools-for-0-13-5/115495#p-2359168-braavos-compatibility-issues-3`
 )
 
 //go:generate mockgen -destination=../mocks/mock_account.go -package=mocks -source=account.go AccountInterface
@@ -112,34 +108,6 @@ func NewAccount(
 	keystore Keystore,
 	cairoVersion CairoVersion,
 ) (*Account, error) {
-	// TODO: Remove this temporary check once solved (starknet v0.14.0 should do it)
-	// This temporary check is to warn the user that Braavos account restricts
-	// transactions to have exactly two resource fields.
-	// This makes them incompatible with transactions sent via RPC 0.8.0
-	accClassHash, err := provider.ClassHashAt(
-		context.Background(),
-		rpc.WithBlockTag("latest"),
-		accountAddress,
-	)
-	// ignoring the error to not break mock tests (if the provider is not
-	// working, it will return an error in the next ChainID call anyway)
-	if err == nil {
-		// Since felt.Felt.String() returns a string without leading zeros, we
-		// need to remove them from the class hashes for the comparison
-		// class hashes for the comparison
-		braavosClassHashes := []string{
-			// Original class hash: 0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc
-			"0x2c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc",
-			// Original class hash: 0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253
-			"0x816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253",
-			// Original class hash: 0x041bf1e71792aecb9df3e9d04e1540091c5e13122a731e02bec588f71dc1a5c3
-			"0x41bf1e71792aecb9df3e9d04e1540091c5e13122a731e02bec588f71dc1a5c3",
-		}
-		if slices.Contains(braavosClassHashes, accClassHash.String()) {
-			fmt.Print(BraavosWarningMessage + "\n\n")
-		}
-	}
-
 	chainID, err := provider.ChainID(context.Background())
 	if err != nil {
 		return nil, err

--- a/account/signature_test.go
+++ b/account/signature_test.go
@@ -24,10 +24,6 @@ func TestVerify(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
 	mockRPCProvider := mocks.NewMockRPCProvider(mockCtrl)
 	mockRPCProvider.EXPECT().ChainID(context.Background()).Return(gomock.Any().String(), nil)
-	// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-	mockRPCProvider.EXPECT().
-		ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-		Return(internalUtils.DeadBeef, nil)
 
 	ks := account.NewMemKeystore()
 	accAddress := internalUtils.TestHexToFelt(

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -294,12 +294,10 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 			Times(2)
 
 		ks, pub, _ := account.GetRandomKeys()
+
 		// called when instantiating the account
-		mockRPCProvider.EXPECT().
-			ClassHashAt(gomock.Any(), gomock.Any(), gomock.Any()).
-			Return(internalUtils.DeadBeef, nil).
-			Times(1)
 		mockRPCProvider.EXPECT().ChainID(gomock.Any()).Return("SN_SEPOLIA", nil).Times(1)
+
 		acnt, err := account.NewAccount(
 			mockRPCProvider,
 			internalUtils.DeadBeef,
@@ -823,10 +821,7 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 	mockRPCProvider := mocks.NewMockRPCProvider(mockCtrl)
 
 	mockRPCProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
-	// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-	mockRPCProvider.EXPECT().
-		ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-		Return(internalUtils.DeadBeef, nil)
+
 	acnt, err := account.NewAccount(
 		mockRPCProvider,
 		&felt.Zero,

--- a/account/txn_hash_test.go
+++ b/account/txn_hash_test.go
@@ -138,10 +138,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 			}
 			if tests.TEST_ENV == "mock" {
 				mockRPCProvider.EXPECT().ChainID(context.Background()).Return(test.ChainID, nil)
-				// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-				mockRPCProvider.EXPECT().
-					ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-					Return(internalUtils.DeadBeef, nil)
+
 				acc, err = account.NewAccount(
 					mockRPCProvider,
 					test.AccountAddress,
@@ -204,10 +201,7 @@ func TestTransactionHashDeclare(t *testing.T) {
 
 		mockRPCProvider := mocks.NewMockRPCProvider(mockCtrl)
 		mockRPCProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
-		// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-		mockRPCProvider.EXPECT().
-			ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-			Return(internalUtils.DeadBeef, nil)
+
 		acnt, err = account.NewAccount(
 			mockRPCProvider,
 			&felt.Zero,
@@ -342,10 +336,7 @@ func TestTransactionHashInvokeV3(t *testing.T) {
 
 	mockRPCProvider := mocks.NewMockRPCProvider(mockCtrl)
 	mockRPCProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
-	// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-	mockRPCProvider.EXPECT().
-		ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-		Return(internalUtils.DeadBeef, nil)
+
 	acnt, err := account.NewAccount(
 		mockRPCProvider,
 		&felt.Zero,
@@ -438,10 +429,6 @@ func TestTransactionHashdeployAccount(t *testing.T) {
 
 	mockRPCProvider := mocks.NewMockRPCProvider(mockCtrl)
 	mockRPCProvider.EXPECT().ChainID(context.Background()).Return("SN_SEPOLIA", nil)
-	// TODO: remove this once the braavos bug is fixed. Ref: https://github.com/NethermindEth/starknet.go/pull/691
-	mockRPCProvider.EXPECT().
-		ClassHashAt(context.Background(), gomock.Any(), gomock.Any()).
-		Return(internalUtils.DeadBeef, nil)
 
 	acnt, err := account.NewAccount(
 		mockRPCProvider,


### PR DESCRIPTION
This PR removes the warning returned when calling the `account.New()` function passing a class hash of a Braavos account.
This was asked by starkware due to a bug in the braavos account, but now this issue was fixed in Starknet v0.14.0