### PR TITLE
refactor: update RPC provider initialization to use context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 -->
 
+### Changed
+- The `rpc.NewProvider` and `rpc.NewWebsocketProvider` functions now accept a `context.Context` parameter.
+
 ## [0.16.0](https://github.com/NethermindEth/starknet.go/releases/tag/v0.16.0) - 2025-10-14
 ### Added
 - New `client/rpcerr` package for handling RPC errors.

--- a/account/account_test.go
+++ b/account/account_test.go
@@ -181,7 +181,7 @@ func TestChainId(t *testing.T) {
 	}[tests.TEST_ENV]
 
 	for _, test := range testSet {
-		client, err := rpc.NewProvider(tConfig.providerURL)
+		client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 
 		acc, err := account.NewAccount(

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -29,7 +29,7 @@ func TestBuildAndSendInvokeTxn(t *testing.T) {
 	// TODO: implement devnet support
 	tests.RunTestOn(t, tests.TestnetEnv)
 
-	provider, err := rpc.NewProvider(tConfig.providerURL)
+	provider, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acc, err := setupAcc(t, provider)
@@ -71,7 +71,7 @@ func TestBuildAndSendDeclareTxn(t *testing.T) {
 	// TODO: implement devnet support
 	tests.RunTestOn(t, tests.TestnetEnv)
 
-	provider, err := rpc.NewProvider(tConfig.providerURL)
+	provider, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acc, err := setupAcc(t, provider)
@@ -125,7 +125,7 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 	// TODO: implement devnet support
 	tests.RunTestOn(t, tests.TestnetEnv)
 
-	provider, err := rpc.NewProvider(tConfig.providerURL)
+	provider, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	// we need this account to fund the new account with STRK tokens, in order to deploy it
@@ -405,7 +405,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 	t.Run("on devnet", func(t *testing.T) {
 		tests.RunTestOn(t, tests.DevnetEnv)
 
-		client, err := rpc.NewProvider(tConfig.providerURL)
+		client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewProvider")
 
 		_, acnts, err := newDevnet(t, tConfig.providerURL)
@@ -563,7 +563,7 @@ func TestSendInvokeTxn(t *testing.T) {
 	}[tests.TEST_ENV]
 
 	for _, test := range testSet {
-		client, err := rpc.NewProvider(tConfig.providerURL)
+		client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewProvider")
 
 		// Set up ks
@@ -641,7 +641,7 @@ func TestSendDeclareTxn(t *testing.T) {
 	require.True(t, ok)
 	ks.Put(PubKey.String(), fakePrivKeyBI)
 
-	client, err := rpc.NewProvider(tConfig.providerURL)
+	client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acnt, err := account.NewAccount(client, AccountAddress, PubKey.String(), ks, account.CairoV0)
@@ -732,7 +732,7 @@ func TestSendDeclareTxn(t *testing.T) {
 func TestSendDeployAccountDevnet(t *testing.T) {
 	tests.RunTestOn(t, tests.DevnetEnv)
 
-	client, err := rpc.NewProvider(tConfig.providerURL)
+	client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	devnetClient, acnts, err := newDevnet(t, tConfig.providerURL)
@@ -915,7 +915,7 @@ func TestWaitForTransactionReceiptMOCK(t *testing.T) {
 func TestWaitForTransactionReceipt(t *testing.T) {
 	tests.RunTestOn(t, tests.DevnetEnv)
 
-	client, err := rpc.NewProvider(tConfig.providerURL)
+	client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	acnt, err := account.NewAccount(
@@ -972,7 +972,7 @@ func TestWaitForTransactionReceipt(t *testing.T) {
 func TestDeployContractWithUDC(t *testing.T) {
 	tests.RunTestOn(t, tests.TestnetEnv)
 
-	provider, err := rpc.NewProvider(tConfig.providerURL)
+	provider, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 	require.NoError(t, err, "Error in rpc.NewProvider")
 
 	accnt, err := setupAcc(t, provider)

--- a/account/txn_hash_test.go
+++ b/account/txn_hash_test.go
@@ -125,7 +125,7 @@ func TestTransactionHashInvoke(t *testing.T) {
 			var err error
 			if tests.TEST_ENV == "testnet" {
 				var client *rpc.Provider
-				client, err = rpc.NewProvider(tConfig.providerURL)
+				client, err = rpc.NewProvider(t.Context(), tConfig.providerURL)
 				require.NoError(t, err, "Error in rpc.NewClient")
 				acc, err = account.NewAccount(
 					client,
@@ -212,7 +212,7 @@ func TestTransactionHashDeclare(t *testing.T) {
 		require.NoError(t, err)
 	}
 	if tests.TEST_ENV == "testnet" {
-		client, err := rpc.NewProvider(tConfig.providerURL)
+		client, err := rpc.NewProvider(t.Context(), tConfig.providerURL)
 		require.NoError(t, err, "Error in rpc.NewClient")
 		acnt, err = account.NewAccount(
 			client,

--- a/examples/deployAccount/main.go
+++ b/examples/deployAccount/main.go
@@ -25,7 +25,7 @@ func main() {
 	rpcProviderURL := setup.GetRPCProviderURL()
 
 	// Initialise the client.
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(err)
 	}

--- a/examples/deployContractUDC/main.go
+++ b/examples/deployContractUDC/main.go
@@ -35,7 +35,7 @@ func main() {
 	publicKey := setup.GetPublicKey()
 
 	// Initialise connection to RPC provider
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %s", err))
 	}

--- a/examples/invoke/main.go
+++ b/examples/invoke/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 
@@ -29,7 +30,7 @@ func main() {
 	publicKey := setup.GetPublicKey()
 
 	// Initialise connection to RPC provider
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %s", err))
 	}

--- a/examples/readEvents/main.go
+++ b/examples/readEvents/main.go
@@ -29,7 +29,7 @@ func main() {
 	wsProviderURL := setup.GetWsProviderURL()
 
 	// Initialise connection to RPC provider
-	provider, err := rpc.NewProvider(rpcProviderURL)
+	provider, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %v", err))
 	}
@@ -329,7 +329,7 @@ func filterWithWebsocket(provider *rpc.Provider, websocketURL string) {
 	fmt.Println()
 	fmt.Println(" ----- 4. filter with websocket -----")
 
-	wsProvider, err := rpc.NewWebsocketProvider(websocketURL)
+	wsProvider, err := rpc.NewWebsocketProvider(context.Background(), websocketURL)
 	if err != nil {
 		panic(fmt.Sprintf("error dialling the RPC provider: %v", err))
 	}

--- a/examples/simpleCall/main.go
+++ b/examples/simpleCall/main.go
@@ -30,7 +30,7 @@ func main() {
 	accountAddress := setup.GetAccountAddress()
 
 	// Initialise connection to RPC provider
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %s", err))
 	}

--- a/examples/simpleDeclare/main.go
+++ b/examples/simpleDeclare/main.go
@@ -29,7 +29,7 @@ func main() {
 	publicKey := setup.GetPublicKey()
 
 	// Initialise connection to RPC provider
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %s", err))
 	}

--- a/examples/typedData/main.go
+++ b/examples/typedData/main.go
@@ -57,7 +57,7 @@ func localSetup() *account.Account {
 	publicKey := setup.GetPublicKey()
 
 	// Initialise connection to RPC provider
-	client, err := rpc.NewProvider(rpcProviderURL)
+	client, err := rpc.NewProvider(context.Background(), rpcProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the RPC provider: %s", err))
 	}

--- a/examples/websocket/main.go
+++ b/examples/websocket/main.go
@@ -16,7 +16,7 @@ func main() {
 	wsProviderURL := setup.GetWsProviderURL()
 
 	// Initialise connection to WS provider
-	wsClient, err := rpc.NewWebsocketProvider(wsProviderURL)
+	wsClient, err := rpc.NewWebsocketProvider(context.Background(), wsProviderURL)
 	if err != nil {
 		panic(fmt.Sprintf("Error dialling the WS provider: %s", err))
 	}

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -1026,7 +1026,7 @@ func TestGetStorageProof(t *testing.T) {
 
 	testConfig := BeforeEach(t, false)
 
-	provider, err := NewProvider(testConfig.Base)
+	provider, err := NewProvider(t.Context(), testConfig.Base)
 	require.NoError(t, err)
 	spy := tests.NewJSONRPCSpy(provider.c)
 	provider.c = spy

--- a/rpc/main_test.go
+++ b/rpc/main_test.go
@@ -55,7 +55,7 @@ func BeforeEach(t *testing.T, isWs bool) *TestConfiguration {
 		testConfig.Base = base
 	}
 
-	client, err := NewProvider(testConfig.Base)
+	client, err := NewProvider(t.Context(), testConfig.Base)
 	if err != nil {
 		t.Fatalf("failed to connect to the %s provider: %v", testConfig.Base, err)
 	}
@@ -74,7 +74,7 @@ func BeforeEach(t *testing.T, isWs bool) *TestConfiguration {
 			testConfig.WsBase = wsBase
 		}
 
-		wsClient, err := NewWebsocketProvider(testConfig.WsBase)
+		wsClient, err := NewWebsocketProvider(t.Context(), testConfig.WsBase)
 		if err != nil {
 			t.Fatalf("failed to connect to the %s websocket provider: %v", testConfig.WsBase, err)
 		}

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -64,7 +64,11 @@ func (ws *WsProvider) Close() {
 }
 
 // NewProvider creates a new HTTP rpc Provider instance.
-func NewProvider(url string, options ...client.ClientOption) (*Provider, error) {
+func NewProvider(
+	ctx context.Context,
+	url string,
+	options ...client.ClientOption,
+) (*Provider, error) {
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
 		return nil, err
@@ -72,7 +76,7 @@ func NewProvider(url string, options ...client.ClientOption) (*Provider, error) 
 	httpClient := &http.Client{Jar: jar} //nolint:exhaustruct // Only the Jar field is used.
 	// prepend the custom client to allow users to override
 	options = append([]client.ClientOption{client.WithHTTPClient(httpClient)}, options...)
-	c, err := client.DialOptions(context.Background(), url, options...)
+	c, err := client.DialOptions(ctx, url, options...)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +90,11 @@ func NewProvider(url string, options ...client.ClientOption) (*Provider, error) 
 }
 
 // NewWebsocketProvider creates a new Websocket rpc Provider instance.
-func NewWebsocketProvider(url string, options ...client.ClientOption) (*WsProvider, error) {
+func NewWebsocketProvider(
+	ctx context.Context,
+	url string,
+	options ...client.ClientOption,
+) (*WsProvider, error) {
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
 		return nil, err
@@ -95,7 +103,7 @@ func NewWebsocketProvider(url string, options ...client.ClientOption) (*WsProvid
 
 	// prepend the custom client to allow users to override
 	options = append([]client.ClientOption{client.WithWebsocketDialer(dialer)}, options...)
-	c, err := client.DialOptions(context.Background(), url, options...)
+	c, err := client.DialOptions(ctx, url, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/rpc/provider_test.go
+++ b/rpc/provider_test.go
@@ -80,7 +80,7 @@ func TestCookieManagement(t *testing.T) {
 	}))
 	defer server.Close()
 
-	client, err := NewProvider(server.URL)
+	client, err := NewProvider(t.Context(), server.URL)
 	require.Nil(t, err)
 
 	resp, err := client.ChainID(context.Background())
@@ -175,7 +175,7 @@ func TestVersionCompatibility(t *testing.T) {
 
 			// Create provider with query parameter - this will trigger the version check
 			serverURL := testServer.URL + "?nodeVersion=" + tc.nodeVersion
-			provider, err := NewProvider(serverURL)
+			provider, err := NewProvider(context.Background(), serverURL)
 			require.NoError(t, err)
 			require.NotNil(t, provider)
 


### PR DESCRIPTION
Modified multiple test files and example implementations to pass a context parameter when creating new RPC providers. This change enhances the flexibility and control over the request lifecycle in the RPC interactions.