### PR TITLE
fix: Overall Fee calculation

### DIFF
--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -161,7 +161,11 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 	require.NotNil(t, precomputedAddress)
 	t.Logf("Precomputed address: %s", precomputedAddress)
 
-	overallFee, err := utils.ResBoundsMapToOverallFee(deployAccTxn.ResourceBounds, 1)
+	overallFee, err := utils.ResBoundsMapToOverallFee(
+		deployAccTxn.ResourceBounds,
+		1,
+		deployAccTxn.Tip,
+	)
 	require.NoError(t, err, "Error converting resource bounds to overall fee")
 
 	// Fund the new account with STRK tokens

--- a/examples/deployAccount/main.go
+++ b/examples/deployAccount/main.go
@@ -65,7 +65,11 @@ func main() {
 
 	// Convert the estimated fee to STRK. The multiplier is 1, as we already estimated the
 	// fee in BuildAndEstimateDeployAccountTxn multiplying by 1.5.
-	overallFee, err := utils.ResBoundsMapToOverallFee(deployAccountTxn.ResourceBounds, 1)
+	overallFee, err := utils.ResBoundsMapToOverallFee(
+		deployAccountTxn.ResourceBounds,
+		1,
+		deployAccountTxn.Tip,
+	)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes the overall fee calculation to include the tip amount.

#### Problem:
The utils.ResBoundsMapToOverallFee function was not considering the tip when calculating the overall fee, causing incorrect fee calculations.
Ref: https://docs.starknet.io/learn/protocol/fees#overall-fee

#### Solution:
- Added a tip parameter (rpc.U64) to ResBoundsMapToOverallFee
- Updated the L2 gas fee calculation to include the tip: (L2GasPrice + tip) * L2GasAmount.

#### Changes:
- Modified utils.ResBoundsMapToOverallFee to accept and use the tip parameter
- Updated fee calculation logic to properly incorporate tip in L2 gas fee computation
- Added test cases covering tip scenarios

This ensures the overall fee calculation matches the Starknet fee formula, including the tip component.