### PR TITLE
Update UDC helpers to use the new UDC contract

### DIFF
--- a/utils/udc.go
+++ b/utils/udc.go
@@ -48,7 +48,15 @@ type UDCOptions struct {
 	//nolint:lll // The links would be unclickable if we break the line.
 	OriginIndependent bool
 	// The UDC version to be used. If not provided, UDCCairoV0 will be used.
-	UDCVersion UDCVersion
+	UDCVersion UDCVersion;
+}
+
+// Creates a new UDCOptions instance
+// UDCCairoV2 will be used as the default UDC version
+func NewUDCOptions() *UDCOptions {
+	return &UDCOptions{
+		UDCVersion: UDCCairoV2,
+	}
 }
 
 // Enum representing the UDC version to be used
@@ -80,13 +88,14 @@ func BuildUDCCalldata(
 	constructorCalldata []*felt.Felt,
 	opts *UDCOptions,
 ) (rpc.InvokeFunctionCall, *felt.Felt, error) {
+opts.UDCVersion = UDCCairoV2 
 	var result rpc.InvokeFunctionCall
 	if classHash == nil {
 		return result, nil, errClassHashNotProvided
 	}
 
 	if opts == nil {
-		opts = new(UDCOptions)
+		opts = NewUDCOptions()
 	}
 
 	// salt

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -21,7 +21,7 @@ var (
 	// https://docs.openzeppelin.com/contracts-cairo/1.0.0/udc#udc_contract_address
 	udcAddressCairoV2, _ = new(
 		felt.Felt,
-	).SetString("0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221")
+	).SetString("0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125")
 
 	errInvalidUDCVersion    = errors.New("invalid UDC version")
 	errClassHashNotProvided = errors.New("classHash not provided")
@@ -59,7 +59,7 @@ const (
 	// address 0x041a78e741e5af2fec34b695679bc6891742439f7afb8484ecd7766661ad02bf
 	UDCCairoV0 UDCVersion = iota
 	// Represents the UDC version with Cairo v2 code, with the
-	// address 0x04a64cd09a853868621d94cae9952b106f2c36a3f81260f85de6696c6b050221
+	// address 0x02ceed65a4bd731034c01113685c831b01c15d7d432f71afb1cf1634b53a2125
 	UDCCairoV2
 )
 

--- a/utils/udc.go
+++ b/utils/udc.go
@@ -88,7 +88,6 @@ func BuildUDCCalldata(
 	constructorCalldata []*felt.Felt,
 	opts *UDCOptions,
 ) (rpc.InvokeFunctionCall, *felt.Felt, error) {
-opts.UDCVersion = UDCCairoV2 
 	var result rpc.InvokeFunctionCall
 	if classHash == nil {
 		return result, nil, errClassHashNotProvided

--- a/utils/udc_test.go
+++ b/utils/udc_test.go
@@ -30,7 +30,7 @@ func TestBuildUDCCalldata(t *testing.T) {
 				new(felt.Felt).SetUint64(100),
 				new(felt.Felt).SetUint64(200),
 			},
-			opts:                  nil,
+			opts:                  &UDCOptions{UDCVersion: UDCCairoV0},
 			expectedUDCAddress:    udcAddressCairoV0,
 			expectedFunctionName:  "deployContract",
 			expectedCallDataLen:   6, // classHash + salt + originInd + calldataLen + 2 constructor args
@@ -40,7 +40,7 @@ func TestBuildUDCCalldata(t *testing.T) {
 			name:                  "UDC Cairo V0 with custom salt",
 			classHash:             internalUtils.DeadBeef,
 			constructorCalldata:   []*felt.Felt{new(felt.Felt).SetUint64(100)},
-			opts:                  &UDCOptions{Salt: new(felt.Felt).SetUint64(999)},
+			opts:                  &UDCOptions{Salt: new(felt.Felt).SetUint64(999), UDCVersion: UDCCairoV0},
 			expectedUDCAddress:    udcAddressCairoV0,
 			expectedFunctionName:  "deployContract",
 			expectedCallDataLen:   5, // classHash + salt + originInd + calldataLen + 1 constructor arg
@@ -50,7 +50,7 @@ func TestBuildUDCCalldata(t *testing.T) {
 			name:                  "UDC Cairo V0 with origin independent",
 			classHash:             internalUtils.DeadBeef,
 			constructorCalldata:   []*felt.Felt{},
-			opts:                  &UDCOptions{OriginIndependent: true},
+			opts:                  &UDCOptions{OriginIndependent: true, UDCVersion: UDCCairoV0},
 			expectedUDCAddress:    udcAddressCairoV0,
 			expectedFunctionName:  "deployContract",
 			expectedCallDataLen:   4, // classHash + salt + originInd + calldataLen
@@ -98,8 +98,8 @@ func TestBuildUDCCalldata(t *testing.T) {
 			classHash:             internalUtils.DeadBeef,
 			constructorCalldata:   []*felt.Felt{},
 			opts:                  nil,
-			expectedUDCAddress:    udcAddressCairoV0,
-			expectedFunctionName:  "deployContract",
+			expectedUDCAddress:    udcAddressCairoV2,
+			expectedFunctionName:  "deploy_contract",
 			expectedCallDataLen:   4, // classHash + salt + originInd + calldataLen
 			checkCallDataContents: true,
 		},
@@ -175,11 +175,11 @@ func checkCallDataContents(
 	}
 
 	// Check the rest based on UDC version
-	if opts != nil && opts.UDCVersion == UDCCairoV2 {
+	if opts == nil || opts.UDCVersion == UDCCairoV2 {
 		// Cairo V2: [classHash, salt, originInd, calldataLen, ...constructorCalldata]
 		originInd := callData[2]
 		expectedOriginInd := new(felt.Felt).SetUint64(0)
-		if opts.OriginIndependent {
+		if opts != nil && opts.OriginIndependent {
 			expectedOriginInd.SetUint64(1)
 		}
 		assert.Equal(t, expectedOriginInd, originInd)


### PR DESCRIPTION
Fixes: #772

Here are the changes I have made:

1. Updated `udcAddressCairoV2` to the new address
2. Added `NewUDCOptions()` which makes `UDCCairoV2` the default value
3. Update tests to expect the new default value

Note: The `TestPrecomputeAddressForUDC` tests still fail, because they rely on hardcoded values from real transactions, which I assume use the old address, so their values will have to be changed too.

Please let me know if this is the expected way of updating the address and setting the default value. The `NewUDCOptions` functions does feel a bit unnecessary for this tiny change, but also less hackey. 