### PR TITLE
build: update checkout action to v6

### DIFF
--- a/.github/workflows/test_paymaster.yml
+++ b/.github/workflows/test_paymaster.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
Updates CI to use `actions/checkout@v6` for improved performance and security.

https://github.com/actions/checkout/releases/tag/v6.0.0