### PR TITLE
fix: incorrect type in `TableHeaderCell`

### DIFF
--- a/docs/docs/components/Table.tsx
+++ b/docs/docs/components/Table.tsx
@@ -56,7 +56,7 @@ TableHead.displayName = "TableHead"
 
 const TableHeaderCell = React.forwardRef<
   HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
+  React.HTMLAttributes<HTMLTableCellElement>
 >(({ className, ...props }, forwardedRef) => (
   <th
     ref={forwardedRef}


### PR DESCRIPTION
spotted that `TableHeaderCell` was using `React.ThHTMLAttributes`, which isn’t a real React type and was blowing up the build. switched it to `React.HTMLAttributes<HTMLTableCellElement>` instead
