### PR TITLE
Implement RPC v0.10.1-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [Unreleased](https://github.com/NethermindEth/starknet.go/compare/v0.17.1...HEAD) <!-- Update the version number on each new release -->
 <!-- template to copy:
 ### Added
@@ -14,6 +15,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 -->
+
+## [0.18.0-beta.2](https://github.com/NethermindEth/starknet.go/releases/tag/v0.18.0-beta.2) - 2026-02-05
+### Added
+- Full support for RPC v0.10.1-rc.2. All new types and changes implemented. For more details, see the [RPC v0.10.1-rc.2](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.1-rc.2) specification.
+  - rpc pkg:
+    - New `AddressList` type.
+    - New `EstimateFeeFlag` enum type + `EstimateFeeSkipValidate` flag.
+    - New `SimulationFlag` enum entry: `ReturnInitialReads` flag.
+    - New `TraceFlag` enum type + `TraceFlagReturnInitialReads` flag.
+    - New `TraceBlockTxsResult` type.
+    - New `SimulateTxResult` type.
+    - New `InitialReads` type + subtypes for its fields.
+    - New `SubscriptionTag` enum type + `SubTagIncludeProofFacts` flag.
+    - New `TxnResponseFlag` enum type + `TxnFlagIncludeProofFacts` flag.
+
+
+### Changed
+  - account pkg:
+    - `TxnOptions.SimulationFlag` field was changed to `EstimateFeeFlags` field, and is now of type `[]rpc.EstimateFeeFlag`.
+    - `TxnOptions.SimulationFlags()` method was changed to `EstimateFlags()` method, and now returns a `[]rpc.EstimateFeeFlag`.
+  - rpc pkg:
+    - methods:
+      - The `provider.BlockWithReceipts` and `provider.BlockWithTxs` methods accept a new `responseFlags` parameter.
+      - In the `provider.EstimateFee` method, the `simulationFlags` parameter is now of type `[]rpc.EstimateFeeFlag`.
+      - The `provider.TraceBlockTransactions` method has a new `traceFlags` parameter, and now returns a `TraceBlockTxsResult` type. 
+      - The `provider.SimulateTransactions` method now returns a `SimulateTxResult` type. 
+      - The `provider.TransactionReceipt` and `provider.TransactionByBlockIDAndIndex` methods accept a new `responseFlags` parameter.
+    - types:
+      - The `InvokeTxnV3` has a new `ProofFacts` field.
+      - The `BroadcastInvokeTxnV3` type is no longer the same as the `InvokeTxnV3` type. Now it's a new type with all the 
+        fields of the `InvokeTxnV3` type, plus the `Proof` and `ProofFacts` fields.
+      - The `EventFilter.Address` field is now of type `AddressList`.
+      - The `EventSubscriptionInput.FromAddress` field is now of type `AddressList`.
+      - The `SubNewTxnsInput` type has a new `Tags` field.
+    
+
+
+## [0.18.0-beta](https://github.com/NethermindEth/starknet.go/releases/tag/v0.18.0-beta) - 2025-11-28
 ### Added
 - Full support for RPC v0.10.0. All new types and changes implemented. For more details, see the [RPC v0.10.0](https://github.com/starkware-libs/starknet-specs/releases/tag/v0.10.0) specification.
   - `ErrContractNotFound` is now returned by the `rpc.EstimateFee` and `rpc.EstimateMessageFee` methods.

--- a/account/signature.go
+++ b/account/signature.go
@@ -41,6 +41,8 @@ func (account *Account) Sign(ctx context.Context, msg *felt.Felt) ([]*felt.Felt,
 //
 // Returns:
 //   - error: an error if there was an error in the signing or invoking process
+//
+//nolint:dupl // The code is similar, but they handle different tx types.
 func (account *Account) SignInvokeTransaction(
 	ctx context.Context,
 	invokeTx rpc.InvokeTxnType,
@@ -59,6 +61,12 @@ func (account *Account) SignInvokeTransaction(
 		}
 		invoke.Signature = signature
 	case *rpc.InvokeTxnV3:
+		signature, err := signInvokeTransaction(ctx, account, invoke)
+		if err != nil {
+			return err
+		}
+		invoke.Signature = signature
+	case *rpc.BroadcastInvokeTxnV3:
 		signature, err := signInvokeTransaction(ctx, account, invoke)
 		if err != nil {
 			return err
@@ -157,6 +165,8 @@ func signDeployAccountTransaction[T rpc.DeployAccountType](
 //
 // Returns:
 //   - error: an error if any
+//
+//nolint:dupl // The code is similar, but they handle different tx types.
 func (account *Account) SignDeclareTransaction(ctx context.Context, tx rpc.DeclareTxnType) error {
 	switch declare := tx.(type) {
 	case *rpc.DeclareTxnV1:

--- a/account/transaction.go
+++ b/account/transaction.go
@@ -75,7 +75,7 @@ func (account *Account) BuildAndSendInvokeTxn(
 	estimateFee, err := account.Provider.EstimateFee(
 		ctx,
 		[]rpc.BroadcastTxn{broadcastInvokeTxnV3},
-		opts.SimulationFlags(),
+		opts.EstimateFlags(),
 		opts.BlockID(),
 	)
 	if err != nil {
@@ -176,7 +176,7 @@ func (account *Account) BuildAndSendDeclareTxn(
 	estimateFee, err := account.Provider.EstimateFee(
 		ctx,
 		[]rpc.BroadcastTxn{broadcastDeclareTxnV3},
-		opts.SimulationFlags(),
+		opts.EstimateFlags(),
 		opts.BlockID(),
 	)
 	if err != nil {
@@ -269,7 +269,7 @@ func (account *Account) BuildAndEstimateDeployAccountTxn(
 	estimateFee, err := account.Provider.EstimateFee(
 		ctx,
 		[]rpc.BroadcastTxn{broadcastDepAccTxnV3},
-		opts.SimulationFlags(),
+		opts.EstimateFlags(),
 		opts.BlockID(),
 	)
 	if err != nil {

--- a/account/transaction_test.go
+++ b/account/transaction_test.go
@@ -64,7 +64,7 @@ func TestBuildAndSendInvokeTxn(t *testing.T) {
 	assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
 
 	// testing the default tip estimation feature
-	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash)
+	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash, nil)
 	require.NoError(t, err, "Error getting transaction by hash")
 	require.NotNil(t, txn)
 	assert.NotEqual(t, "0x0", txn.Transaction.(rpc.InvokeTxnV3).Tip)
@@ -130,7 +130,7 @@ func TestBuildAndSendDeclareTxn(t *testing.T) {
 	assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
 
 	// testing the default tip estimation feature
-	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash)
+	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash, nil)
 	require.NoError(t, err, "Error getting transaction by hash")
 	require.NotNil(t, txn)
 	assert.NotEqual(t, "0x0", txn.Transaction.(rpc.DeclareTxnV3).Tip)
@@ -226,7 +226,7 @@ func TestBuildAndSendDeclareTxnMock(t *testing.T) {
 					Return(new(felt.Felt).SetUint64(1), nil).
 					Times(1)
 				mockRPCProvider.EXPECT().
-					BlockWithTxs(t.Context(), rpc.WithBlockTag(rpc.BlockTagLatest)).
+					BlockWithTxs(t.Context(), rpc.WithBlockTag(rpc.BlockTagLatest), nil).
 					Return(&rpc.Block{}, nil).Times(1)
 				mockRPCProvider.EXPECT().
 					EstimateFee(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
@@ -361,7 +361,7 @@ func TestBuildAndEstimateDeployAccountTxn(t *testing.T) {
 	assert.Equal(t, rpc.TxnExecutionStatusSUCCEEDED, txReceipt.ExecutionStatus)
 
 	// testing the default tip estimation feature
-	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash)
+	txn, err := acc.Provider.TransactionByHash(t.Context(), resp.Hash, nil)
 	require.NoError(t, err, "Error getting transaction by hash")
 	require.NotNil(t, txn)
 	assert.NotEqual(t, "0x0", txn.Transaction.(rpc.DeployAccountTxnV3).Tip)
@@ -528,7 +528,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 		)
 		// called when estimating the tip
 		mockRPCProvider.EXPECT().
-			BlockWithTxs(t.Context(), rpc.WithBlockTag(rpc.BlockTagLatest)).
+			BlockWithTxs(t.Context(), rpc.WithBlockTag(rpc.BlockTagLatest), nil).
 			Return(&rpc.Block{
 				BlockHeader: rpc.BlockHeader{},
 				Status:      rpc.BlockStatusAcceptedOnL2,
@@ -636,7 +636,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			txn, err := client.TransactionByHash(t.Context(), resp.Hash)
+			txn, err := client.TransactionByHash(t.Context(), resp.Hash, nil)
 			require.NoError(t, err)
 
 			// assert the returned transaction does NOT have the query bit version
@@ -664,7 +664,7 @@ func TestBuildAndSendMethodsWithQueryBit(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			txn, err := client.TransactionByHash(t.Context(), resp.Hash)
+			txn, err := client.TransactionByHash(t.Context(), resp.Hash, nil)
 			require.NoError(t, err)
 
 			// assert the returned transaction does NOT have the query bit version

--- a/account/txn_hash.go
+++ b/account/txn_hash.go
@@ -74,6 +74,43 @@ func (account *Account) TransactionHashInvoke(tx rpc.InvokeTxnType) (*felt.Felt,
 		return hash.TransactionHashInvokeV3(txn, account.ChainID)
 	case rpc.InvokeTxnV3:
 		return hash.TransactionHashInvokeV3(&txn, account.ChainID)
+	// broadcast invoke v3, pointer and struct
+	case *rpc.BroadcastInvokeTxnV3:
+		invokeTxn := rpc.InvokeTxnV3{
+			Type:                  txn.Type,
+			SenderAddress:         txn.SenderAddress,
+			Calldata:              txn.Calldata,
+			Version:               txn.Version,
+			Signature:             txn.Signature,
+			Nonce:                 txn.Nonce,
+			ResourceBounds:        txn.ResourceBounds,
+			Tip:                   txn.Tip,
+			PayMasterData:         txn.PayMasterData,
+			AccountDeploymentData: txn.AccountDeploymentData,
+			NonceDataMode:         txn.NonceDataMode,
+			FeeMode:               txn.FeeMode,
+			ProofFacts:            txn.ProofFacts,
+		}
+
+		return hash.TransactionHashInvokeV3(&invokeTxn, account.ChainID)
+	case rpc.BroadcastInvokeTxnV3:
+		invokeTxn := rpc.InvokeTxnV3{
+			Type:                  txn.Type,
+			SenderAddress:         txn.SenderAddress,
+			Calldata:              txn.Calldata,
+			Version:               txn.Version,
+			Signature:             txn.Signature,
+			Nonce:                 txn.Nonce,
+			ResourceBounds:        txn.ResourceBounds,
+			Tip:                   txn.Tip,
+			PayMasterData:         txn.PayMasterData,
+			AccountDeploymentData: txn.AccountDeploymentData,
+			NonceDataMode:         txn.NonceDataMode,
+			FeeMode:               txn.FeeMode,
+			ProofFacts:            txn.ProofFacts,
+		}
+
+		return hash.TransactionHashInvokeV3(&invokeTxn, account.ChainID)
 	default:
 		return nil, fmt.Errorf(
 			"%w: got '%T' instead of a valid invoke txn type",

--- a/account/txn_options.go
+++ b/account/txn_options.go
@@ -43,8 +43,8 @@ type TxnOptions struct {
 	// A boolean flag indicating whether to use the latest block tag
 	// when estimating fees instead of the pre_confirmed block. Default: `false`.
 	UseLatest bool
-	// The simulation flag to be used when estimating fees. Default: none.
-	SimulationFlag rpc.SimulationFlag
+	// The estimate fee flags to be used when estimating fees. Default: none.
+	EstimateFeeFlags []rpc.EstimateFeeFlag
 
 	// ONLY FOR THE `BuildAndSendDeclareTxn` METHOD: A pointer to a boolean flag
 	// indicating whether to use the Blake2s hash function to calculate the compiled
@@ -66,14 +66,14 @@ func (opts *TxnOptions) BlockID() rpc.BlockID {
 	return rpc.WithBlockTag(rpc.BlockTagPreConfirmed)
 }
 
-// Returns a `[]rpc.SimulationFlag` containing the SimulationFlag.
-// If the flag is not set, returns an empty slice.
-func (opts *TxnOptions) SimulationFlags() []rpc.SimulationFlag {
-	if opts.SimulationFlag == "" {
-		return []rpc.SimulationFlag{}
+// Returns a `[]rpc.EstimateFeeFlag` containing the EstimateFeeFlag.
+// If no flags are set/is nil, returns an empty slice.
+func (opts *TxnOptions) EstimateFlags() []rpc.EstimateFeeFlag {
+	if len(opts.EstimateFeeFlags) == 0 {
+		return []rpc.EstimateFeeFlag{}
 	}
 
-	return []rpc.SimulationFlag{opts.SimulationFlag}
+	return opts.EstimateFeeFlags
 }
 
 // FmtFeeMultiplier returns the fee multiplier specified in the options.

--- a/account/txn_options_test.go
+++ b/account/txn_options_test.go
@@ -166,31 +166,24 @@ func TestTxnOptions(t *testing.T) {
 		testcases := []struct {
 			name             string
 			opts             *TxnOptions
-			expectedSimFlags []rpc.SimulationFlag
+			expectedSimFlags []rpc.EstimateFeeFlag
 		}{
 			{
 				name:             "Default value (nil)",
 				opts:             nil,
-				expectedSimFlags: []rpc.SimulationFlag{},
+				expectedSimFlags: []rpc.EstimateFeeFlag{},
 			},
 			{
-				name:             "Empty simulation flag",
-				opts:             &TxnOptions{SimulationFlag: ""},
-				expectedSimFlags: []rpc.SimulationFlag{},
+				name:             "Nil estimate fee flags",
+				opts:             &TxnOptions{EstimateFeeFlags: nil},
+				expectedSimFlags: []rpc.EstimateFeeFlag{},
 			},
 			{
 				name: "SKIP_VALIDATE flag",
 				opts: &TxnOptions{
-					SimulationFlag: rpc.SkipValidate,
+					EstimateFeeFlags: []rpc.EstimateFeeFlag{rpc.EstimateFeeSkipValidate},
 				},
-				expectedSimFlags: []rpc.SimulationFlag{rpc.SkipValidate},
-			},
-			{
-				name: "SKIP_FEE_CHARGE flag",
-				opts: &TxnOptions{
-					SimulationFlag: rpc.SkipFeeCharge,
-				},
-				expectedSimFlags: []rpc.SimulationFlag{rpc.SkipFeeCharge},
+				expectedSimFlags: []rpc.EstimateFeeFlag{rpc.EstimateFeeSkipValidate},
 			},
 		}
 
@@ -200,7 +193,7 @@ func TestTxnOptions(t *testing.T) {
 				if tt.opts == nil {
 					tt.opts = new(TxnOptions)
 				}
-				assert.Equal(t, tt.expectedSimFlags, tt.opts.SimulationFlags())
+				assert.Equal(t, tt.expectedSimFlags, tt.opts.EstimateFlags())
 			})
 		}
 	})

--- a/examples/invoke/verboseInvoke.go
+++ b/examples/invoke/verboseInvoke.go
@@ -81,7 +81,7 @@ func verboseInvoke(
 	feeRes, err := accnt.Provider.EstimateFee(
 		context.Background(),
 		[]rpc.BroadcastTxn{InvokeTx},
-		[]rpc.SimulationFlag{},
+		[]rpc.EstimateFeeFlag{},
 		rpc.WithBlockTag("pre_confirmed"),
 	)
 	if err != nil {

--- a/examples/readEvents/main.go
+++ b/examples/readEvents/main.go
@@ -355,7 +355,7 @@ func filterWithWebsocket(provider *rpc.Provider, websocketURL string) {
 		eventsChan,
 		&rpc.EventSubscriptionInput{
 			// Only events from this contract address
-			FromAddress: contractAddress,
+			FromAddress: rpc.AddressList{contractAddress},
 			// Subscribe to events from the latest block minus 10 (it'll return
 			// events from the last 10 blocks and progressively update as new blocks are added)
 			SubBlockID: new(rpc.SubscriptionBlockID).WithBlockNumber(blockNumber - 10),

--- a/examples/readEvents/main.go
+++ b/examples/readEvents/main.go
@@ -72,9 +72,9 @@ func main() {
 
 	eventChunk, err := provider.Events(context.Background(), rpc.EventsInput{
 		EventFilter: rpc.EventFilter{
-			FromBlock: rpc.WithBlockNumber(660000), // from block 660000
-			ToBlock:   rpc.WithBlockNumber(660100), // to block 660100
-			Address:   contractAddress,             // sent from this contract address
+			FromBlock: rpc.WithBlockNumber(660000),   // from block 660000
+			ToBlock:   rpc.WithBlockNumber(660100),   // to block 660100
+			Address:   []*felt.Felt{contractAddress}, // sent from this contract address
 			Keys: [][]*felt.Felt{
 				// Here we are filtering all 'Transfer', 'Approval' and 'GameStarted' events.
 				// (all events that have one of these selectors as the first key)
@@ -185,7 +185,7 @@ func callWithBlockAndAddressFilters(provider *rpc.Provider) {
 		EventFilter: rpc.EventFilter{
 			FromBlock: rpc.WithBlockNumber(0),
 			ToBlock:   rpc.WithBlockNumber(100),
-			Address:   contractAddress,
+			Address:   []*felt.Felt{contractAddress},
 		},
 		ResultPageRequest: rpc.ResultPageRequest{
 			ChunkSize: 1000,

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -488,7 +488,7 @@ func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainID *felt.Felt) (*felt.Fe
 		return nil, err
 	}
 
-	return curve.PoseidonArray(
+	hashContent := []*felt.Felt{
 		prefixInvoke,
 		txnVersionFelt,
 		txn.SenderAddress,
@@ -499,7 +499,13 @@ func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainID *felt.Felt) (*felt.Fe
 		felt.NewFromUint64[felt.Felt](DAUint64),
 		curve.PoseidonArray(txn.AccountDeploymentData...),
 		curve.PoseidonArray(txn.Calldata...),
-	), nil
+	}
+
+	if txn.ProofFacts != nil {
+		hashContent = append(hashContent, curve.PoseidonArray(txn.ProofFacts...))
+	}
+
+	return curve.PoseidonArray(hashContent...), nil
 }
 
 // TransactionHashDeclareV1 calculates the transaction hash for a declare V1 transaction.

--- a/hash/hash.go
+++ b/hash/hash.go
@@ -501,7 +501,7 @@ func TransactionHashInvokeV3(txn *rpc.InvokeTxnV3, chainID *felt.Felt) (*felt.Fe
 		curve.PoseidonArray(txn.Calldata...),
 	}
 
-	if txn.ProofFacts != nil {
+	if len(txn.ProofFacts) > 0 {
 		hashContent = append(hashContent, curve.PoseidonArray(txn.ProofFacts...))
 	}
 

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -345,10 +345,10 @@ func (mr *MockRPCProviderMockRecorder) Nonce(ctx, blockID, contractAddress any) 
 }
 
 // SimulateTransactions mocks base method.
-func (m *MockRPCProvider) SimulateTransactions(ctx context.Context, blockID rpc.BlockID, txns []rpc.BroadcastTxn, simulationFlags []rpc.SimulationFlag) ([]rpc.SimulatedTransaction, error) {
+func (m *MockRPCProvider) SimulateTransactions(ctx context.Context, blockID rpc.BlockID, txns []rpc.BroadcastTxn, simulationFlags []rpc.SimulationFlag) (rpc.SimulateTxResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulateTransactions", ctx, blockID, txns, simulationFlags)
-	ret0, _ := ret[0].([]rpc.SimulatedTransaction)
+	ret0, _ := ret[0].(rpc.SimulateTxResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -135,18 +135,18 @@ func (mr *MockRPCProviderMockRecorder) BlockTransactionCount(ctx, blockID any) *
 }
 
 // BlockWithReceipts mocks base method.
-func (m *MockRPCProvider) BlockWithReceipts(ctx context.Context, blockID rpc.BlockID) (any, error) {
+func (m *MockRPCProvider) BlockWithReceipts(ctx context.Context, blockID rpc.BlockID, responseFlags []rpc.TxnResponseFlag) (any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockWithReceipts", ctx, blockID)
+	ret := m.ctrl.Call(m, "BlockWithReceipts", ctx, blockID, responseFlags)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockWithReceipts indicates an expected call of BlockWithReceipts.
-func (mr *MockRPCProviderMockRecorder) BlockWithReceipts(ctx, blockID any) *gomock.Call {
+func (mr *MockRPCProviderMockRecorder) BlockWithReceipts(ctx, blockID, responseFlags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockWithReceipts", reflect.TypeOf((*MockRPCProvider)(nil).BlockWithReceipts), ctx, blockID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockWithReceipts", reflect.TypeOf((*MockRPCProvider)(nil).BlockWithReceipts), ctx, blockID, responseFlags)
 }
 
 // BlockWithTxHashes mocks base method.
@@ -165,18 +165,18 @@ func (mr *MockRPCProviderMockRecorder) BlockWithTxHashes(ctx, blockID any) *gomo
 }
 
 // BlockWithTxs mocks base method.
-func (m *MockRPCProvider) BlockWithTxs(ctx context.Context, blockID rpc.BlockID) (any, error) {
+func (m *MockRPCProvider) BlockWithTxs(ctx context.Context, blockID rpc.BlockID, responseFlags []rpc.TxnResponseFlag) (any, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BlockWithTxs", ctx, blockID)
+	ret := m.ctrl.Call(m, "BlockWithTxs", ctx, blockID, responseFlags)
 	ret0, _ := ret[0].(any)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // BlockWithTxs indicates an expected call of BlockWithTxs.
-func (mr *MockRPCProviderMockRecorder) BlockWithTxs(ctx, blockID any) *gomock.Call {
+func (mr *MockRPCProviderMockRecorder) BlockWithTxs(ctx, blockID, responseFlags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockWithTxs", reflect.TypeOf((*MockRPCProvider)(nil).BlockWithTxs), ctx, blockID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlockWithTxs", reflect.TypeOf((*MockRPCProvider)(nil).BlockWithTxs), ctx, blockID, responseFlags)
 }
 
 // Call mocks base method.
@@ -465,33 +465,33 @@ func (mr *MockRPCProviderMockRecorder) TraceTransaction(ctx, transactionHash any
 }
 
 // TransactionByBlockIDAndIndex mocks base method.
-func (m *MockRPCProvider) TransactionByBlockIDAndIndex(ctx context.Context, blockID rpc.BlockID, index uint64) (*rpc.BlockTransaction, error) {
+func (m *MockRPCProvider) TransactionByBlockIDAndIndex(ctx context.Context, blockID rpc.BlockID, index uint64, responseFlags []rpc.TxnResponseFlag) (*rpc.BlockTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransactionByBlockIDAndIndex", ctx, blockID, index)
+	ret := m.ctrl.Call(m, "TransactionByBlockIDAndIndex", ctx, blockID, index, responseFlags)
 	ret0, _ := ret[0].(*rpc.BlockTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TransactionByBlockIDAndIndex indicates an expected call of TransactionByBlockIDAndIndex.
-func (mr *MockRPCProviderMockRecorder) TransactionByBlockIDAndIndex(ctx, blockID, index any) *gomock.Call {
+func (mr *MockRPCProviderMockRecorder) TransactionByBlockIDAndIndex(ctx, blockID, index, responseFlags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionByBlockIDAndIndex", reflect.TypeOf((*MockRPCProvider)(nil).TransactionByBlockIDAndIndex), ctx, blockID, index)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionByBlockIDAndIndex", reflect.TypeOf((*MockRPCProvider)(nil).TransactionByBlockIDAndIndex), ctx, blockID, index, responseFlags)
 }
 
 // TransactionByHash mocks base method.
-func (m *MockRPCProvider) TransactionByHash(ctx context.Context, hash *felt.Felt) (*rpc.BlockTransaction, error) {
+func (m *MockRPCProvider) TransactionByHash(ctx context.Context, hash *felt.Felt, responseFlags []rpc.TxnResponseFlag) (*rpc.BlockTransaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TransactionByHash", ctx, hash)
+	ret := m.ctrl.Call(m, "TransactionByHash", ctx, hash, responseFlags)
 	ret0, _ := ret[0].(*rpc.BlockTransaction)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TransactionByHash indicates an expected call of TransactionByHash.
-func (mr *MockRPCProviderMockRecorder) TransactionByHash(ctx, hash any) *gomock.Call {
+func (mr *MockRPCProviderMockRecorder) TransactionByHash(ctx, hash, responseFlags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionByHash", reflect.TypeOf((*MockRPCProvider)(nil).TransactionByHash), ctx, hash)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionByHash", reflect.TypeOf((*MockRPCProvider)(nil).TransactionByHash), ctx, hash, responseFlags)
 }
 
 // TransactionReceipt mocks base method.

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -435,18 +435,18 @@ func (mr *MockRPCProviderMockRecorder) Syncing(ctx any) *gomock.Call {
 }
 
 // TraceBlockTransactions mocks base method.
-func (m *MockRPCProvider) TraceBlockTransactions(ctx context.Context, blockID rpc.BlockID) (rpc.TraceBlockTxsResult, error) {
+func (m *MockRPCProvider) TraceBlockTransactions(ctx context.Context, blockID rpc.BlockID, traceFlags []rpc.TraceFlag) (rpc.TraceBlockTxsResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TraceBlockTransactions", ctx, blockID)
+	ret := m.ctrl.Call(m, "TraceBlockTransactions", ctx, blockID, traceFlags)
 	ret0, _ := ret[0].(rpc.TraceBlockTxsResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // TraceBlockTransactions indicates an expected call of TraceBlockTransactions.
-func (mr *MockRPCProviderMockRecorder) TraceBlockTransactions(ctx, blockID any) *gomock.Call {
+func (mr *MockRPCProviderMockRecorder) TraceBlockTransactions(ctx, blockID, traceFlags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBlockTransactions", reflect.TypeOf((*MockRPCProvider)(nil).TraceBlockTransactions), ctx, blockID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TraceBlockTransactions", reflect.TypeOf((*MockRPCProvider)(nil).TraceBlockTransactions), ctx, blockID, traceFlags)
 }
 
 // TraceTransaction mocks base method.

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -435,10 +435,10 @@ func (mr *MockRPCProviderMockRecorder) Syncing(ctx any) *gomock.Call {
 }
 
 // TraceBlockTransactions mocks base method.
-func (m *MockRPCProvider) TraceBlockTransactions(ctx context.Context, blockID rpc.BlockID) ([]rpc.Trace, error) {
+func (m *MockRPCProvider) TraceBlockTransactions(ctx context.Context, blockID rpc.BlockID) (rpc.TraceBlockTxsResult, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TraceBlockTransactions", ctx, blockID)
-	ret0, _ := ret[0].([]rpc.Trace)
+	ret0, _ := ret[0].(rpc.TraceBlockTxsResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/internal/tests/mocks/rpcv10mock/rpc.go
+++ b/internal/tests/mocks/rpcv10mock/rpc.go
@@ -270,7 +270,7 @@ func (mr *MockRPCProviderMockRecorder) CompiledCasm(ctx, classHash any) *gomock.
 }
 
 // EstimateFee mocks base method.
-func (m *MockRPCProvider) EstimateFee(ctx context.Context, requests []rpc.BroadcastTxn, simulationFlags []rpc.SimulationFlag, blockID rpc.BlockID) ([]rpc.FeeEstimation, error) {
+func (m *MockRPCProvider) EstimateFee(ctx context.Context, requests []rpc.BroadcastTxn, simulationFlags []rpc.EstimateFeeFlag, blockID rpc.BlockID) ([]rpc.FeeEstimation, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "EstimateFee", ctx, requests, simulationFlags, blockID)
 	ret0, _ := ret[0].([]rpc.FeeEstimation)

--- a/rpc/block.go
+++ b/rpc/block.go
@@ -179,15 +179,28 @@ func (provider *Provider) BlockTransactionCount(
 // Parameters:
 //   - ctx: The context.Context object for the request
 //   - blockID: The ID of the block to retrieve
+//   - responseFlags: Flags that control what additional fields are included
+//     in transaction responses. Pass nil for default behavior.
 //
 // Returns:
 //   - interface{}: The retrieved block
 //   - error: An error, if any
 //
 //nolint:dupl // Similar to BlockWithTxHashes, but it's a different method.
-func (provider *Provider) BlockWithTxs(ctx context.Context, blockID BlockID) (interface{}, error) {
+func (provider *Provider) BlockWithTxs(
+	ctx context.Context,
+	blockID BlockID,
+	responseFlags []TxnResponseFlag,
+) (interface{}, error) {
 	var result Block
-	if err := do(ctx, provider.c, "starknet_getBlockWithTxs", &result, blockID); err != nil {
+	if err := do(
+		ctx,
+		provider.c,
+		"starknet_getBlockWithTxs",
+		&result,
+		blockID,
+		responseFlags,
+	); err != nil {
 		return nil, rpcerr.UnwrapToRPCErr(err, ErrBlockNotFound)
 	}
 	// if header.Hash == nil it's a pre_confirmed block
@@ -211,12 +224,30 @@ func (provider *Provider) BlockWithTxs(ctx context.Context, blockID BlockID) (in
 }
 
 // Get block information with full transactions and receipts given the block id
+//
+// Parameters:
+//   - ctx: The context.Context object for the request
+//   - blockID: The ID of the block to retrieve
+//   - responseFlags: Flags that control what additional fields are included
+//     in transaction responses. Pass nil for default behavior.
+//
+// Returns:
+//   - interface{}: The retrieved block
+//   - error: An error, if any
 func (provider *Provider) BlockWithReceipts(
 	ctx context.Context,
 	blockID BlockID,
+	responseFlags []TxnResponseFlag,
 ) (interface{}, error) {
 	var result json.RawMessage
-	if err := do(ctx, provider.c, "starknet_getBlockWithReceipts", &result, blockID); err != nil {
+	if err := do(
+		ctx,
+		provider.c,
+		"starknet_getBlockWithReceipts",
+		&result,
+		blockID,
+		responseFlags,
+	); err != nil {
 		return nil, rpcerr.UnwrapToRPCErr(err, ErrBlockNotFound)
 	}
 

--- a/rpc/block.go
+++ b/rpc/block.go
@@ -101,7 +101,7 @@ func WithBlockTag(tag BlockTag) BlockID {
 //   - interface{}: The retrieved block
 //   - error: An error, if any
 //
-//nolint:dupl // Similar to BlockWithTxs, but it's a different method.
+
 func (provider *Provider) BlockWithTxHashes(
 	ctx context.Context,
 	blockID BlockID,
@@ -180,13 +180,13 @@ func (provider *Provider) BlockTransactionCount(
 //   - ctx: The context.Context object for the request
 //   - blockID: The ID of the block to retrieve
 //   - responseFlags: Flags that control what additional fields are included
-//     in transaction responses. Pass nil for default behavior.
+//     in transaction responses. Pass nil for default behaviour.
 //
 // Returns:
 //   - interface{}: The retrieved block
 //   - error: An error, if any
 //
-//nolint:dupl // Similar to BlockWithTxHashes, but it's a different method.
+
 func (provider *Provider) BlockWithTxs(
 	ctx context.Context,
 	blockID BlockID,
@@ -229,7 +229,7 @@ func (provider *Provider) BlockWithTxs(
 //   - ctx: The context.Context object for the request
 //   - blockID: The ID of the block to retrieve
 //   - responseFlags: Flags that control what additional fields are included
-//     in transaction responses. Pass nil for default behavior.
+//     in transaction responses. Pass nil for default behaviour.
 //
 // Returns:
 //   - interface{}: The retrieved block

--- a/rpc/block_test.go
+++ b/rpc/block_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/internal/tests"
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
 	"github.com/stretchr/testify/assert"
@@ -245,8 +246,9 @@ func TestBlockWithTxs(t *testing.T) {
 	provider := testConfig.Provider
 
 	type testSetType struct {
-		BlockID     BlockID
-		ExpectedErr error
+		BlockID       BlockID
+		ExpectedErr   error
+		ResponseFlags []TxnResponseFlag
 	}
 
 	testSet := map[tests.TestEnv][]testSetType{
@@ -258,6 +260,10 @@ func TestBlockWithTxs(t *testing.T) {
 				BlockID: WithBlockTag(BlockTagLatest),
 			},
 			{
+				BlockID:       WithBlockNumber(1),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
+			{
 				BlockID:     WithBlockNumber(99999999999999999),
 				ExpectedErr: ErrBlockNotFound,
 			},
@@ -267,17 +273,29 @@ func TestBlockWithTxs(t *testing.T) {
 				BlockID:     WithBlockNumber(99999999999999999),
 				ExpectedErr: ErrBlockNotFound,
 			},
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
 		},
 		tests.MainnetEnv: {
 			{
 				BlockID:     WithBlockNumber(99999999999999999),
 				ExpectedErr: ErrBlockNotFound,
 			},
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
 		},
 		tests.TestnetEnv: {
 			{
 				BlockID:     WithBlockNumber(99999999999999999),
 				ExpectedErr: ErrBlockNotFound,
+			},
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
 			},
 		},
 	}[tests.TEST_ENV]
@@ -299,6 +317,9 @@ func TestBlockWithTxs(t *testing.T) {
 				blockSepolia3100000 := internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
 					t,
 					"./testData/blockWithTxns/sepolia3100000.json", "result",
+				)
+				blockSepolia3100000WithFlags := json.RawMessage(
+					"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
 				)
 
 				blockSepoliaPreConfirmed := internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
@@ -326,10 +347,15 @@ func TestBlockWithTxs(t *testing.T) {
 								*rawResp = blockSepolia3100000
 							}
 
-							if blockID.Number != nil && *blockID.Number == 99999999999999999 {
-								return RPCError{
-									Code:    24,
-									Message: "Block not found",
+							if blockID.Number != nil {
+								switch *blockID.Number {
+								case 1:
+									*rawResp = blockSepolia3100000WithFlags
+								case 99999999999999999:
+									return RPCError{
+										Code:    24,
+										Message: "Block not found",
+									}
 								}
 							}
 
@@ -342,6 +368,7 @@ func TestBlockWithTxs(t *testing.T) {
 			blockWithTxsInterface, err := provider.BlockWithTxs(
 				t.Context(),
 				test.BlockID,
+				test.ResponseFlags,
 			)
 			if test.ExpectedErr != nil {
 				require.Error(t, err)
@@ -616,8 +643,9 @@ func TestBlockWithReceipts(t *testing.T) {
 	provider := testConfig.Provider
 
 	type testSetType struct {
-		BlockID     BlockID
-		ExpectedErr error
+		BlockID       BlockID
+		ResponseFlags []TxnResponseFlag
+		ExpectedErr   error
 	}
 
 	testSet := map[tests.TestEnv][]testSetType{
@@ -629,11 +657,19 @@ func TestBlockWithReceipts(t *testing.T) {
 				BlockID: WithBlockTag(BlockTagLatest),
 			},
 			{
+				BlockID:     WithBlockHash(felt.NewFromUint64[felt.Felt](1)),
+				ExpectedErr: ErrBlockNotFound,
+			},
+			{
 				BlockID:     WithBlockHash(internalUtils.DeadBeef),
 				ExpectedErr: ErrBlockNotFound,
 			},
 		},
 		tests.IntegrationEnv: {
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
 			{
 				BlockID:     WithBlockHash(internalUtils.DeadBeef),
 				ExpectedErr: ErrBlockNotFound,
@@ -641,11 +677,19 @@ func TestBlockWithReceipts(t *testing.T) {
 		},
 		tests.MainnetEnv: {
 			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
+			{
 				BlockID:     WithBlockHash(internalUtils.DeadBeef),
 				ExpectedErr: ErrBlockNotFound,
 			},
 		},
 		tests.TestnetEnv: {
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
 			{
 				BlockID:     WithBlockHash(internalUtils.DeadBeef),
 				ExpectedErr: ErrBlockNotFound,
@@ -670,6 +714,9 @@ func TestBlockWithReceipts(t *testing.T) {
 				blockSepolia3100000 := internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
 					t,
 					"./testData/blockWithReceipts/sepolia3100000.json", "result",
+				)
+				blockSepolia3100000WithFlags := json.RawMessage(
+					"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
 				)
 
 				blockSepoliaPreConfirmed := internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
@@ -697,10 +744,15 @@ func TestBlockWithReceipts(t *testing.T) {
 								*rawResp = blockSepolia3100000
 							}
 
-							if blockID.Hash != nil && blockID.Hash == internalUtils.DeadBeef {
-								return RPCError{
-									Code:    24,
-									Message: "Block not found",
+							if blockID.Hash != nil {
+								switch blockID.Hash {
+								case felt.NewFromUint64[felt.Felt](1):
+									*rawResp = blockSepolia3100000WithFlags
+								case internalUtils.DeadBeef:
+									return RPCError{
+										Code:    24,
+										Message: "Block not found",
+									}
 								}
 							}
 
@@ -709,7 +761,7 @@ func TestBlockWithReceipts(t *testing.T) {
 					).
 					Times(1)
 			}
-			result, err := provider.BlockWithReceipts(t.Context(), test.BlockID)
+			result, err := provider.BlockWithReceipts(t.Context(), test.BlockID, test.ResponseFlags)
 			if test.ExpectedErr != nil {
 				require.Error(t, err)
 				assert.EqualError(t, err, test.ExpectedErr.Error())

--- a/rpc/contract.go
+++ b/rpc/contract.go
@@ -189,7 +189,7 @@ func (provider *Provider) Nonce(
 func (provider *Provider) EstimateFee(
 	ctx context.Context,
 	requests []BroadcastTxn,
-	simulationFlags []SimulationFlag,
+	simulationFlags []EstimateFeeFlag,
 	blockID BlockID,
 ) ([]FeeEstimation, error) {
 	var raw []FeeEstimation

--- a/rpc/contract_test.go
+++ b/rpc/contract_test.go
@@ -951,7 +951,7 @@ func TestEstimateFee(t *testing.T) {
 	type testSetType struct {
 		description   string
 		txs           []BroadcastTxn
-		simFlags      []SimulationFlag
+		simFlags      []EstimateFeeFlag
 		blockID       BlockID
 		expectedError *RPCError
 	}
@@ -977,7 +977,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					sepoliaInvokeV3,
 				},
-				simFlags: []SimulationFlag{},
+				simFlags: []EstimateFeeFlag{},
 				blockID:  WithBlockTag(BlockTagLatest),
 			},
 			{
@@ -985,7 +985,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					sepoliaInvokeV3,
 				},
-				simFlags: []SimulationFlag{SkipValidate},
+				simFlags: []EstimateFeeFlag{EstimateFeeSkipValidate},
 				blockID:  WithBlockTag(BlockTagLatest),
 			},
 			{
@@ -1011,7 +1011,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					sepoliaInvokeV3,
 				},
-				simFlags:      []SimulationFlag{},
+				simFlags:      []EstimateFeeFlag{},
 				blockID:       WithBlockNumber(574447),
 				expectedError: nil,
 			},
@@ -1020,7 +1020,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					sepoliaInvokeV3,
 				},
-				simFlags:      []SimulationFlag{SkipValidate},
+				simFlags:      []EstimateFeeFlag{EstimateFeeSkipValidate},
 				blockID:       WithBlockNumber(574447),
 				expectedError: nil,
 			},
@@ -1049,7 +1049,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					integrationInvokeV3,
 				},
-				simFlags:      []SimulationFlag{},
+				simFlags:      []EstimateFeeFlag{},
 				blockID:       WithBlockNumber(1_300_000),
 				expectedError: nil,
 			},
@@ -1058,7 +1058,7 @@ func TestEstimateFee(t *testing.T) {
 				txs: []BroadcastTxn{
 					integrationInvokeV3,
 				},
-				simFlags:      []SimulationFlag{SkipValidate},
+				simFlags:      []EstimateFeeFlag{EstimateFeeSkipValidate},
 				blockID:       WithBlockNumber(1_300_000),
 				expectedError: nil,
 			},

--- a/rpc/events_test.go
+++ b/rpc/events_test.go
@@ -35,10 +35,12 @@ func TestEvents(t *testing.T) {
 	evFilter := EventFilter{
 		FromBlock: WithBlockNumber(2000000),
 		ToBlock:   WithBlockNumber(2000100),
-		Address: internalUtils.TestHexToFelt(
-			t,
-			"0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
-		),
+		Address: []*felt.Felt{
+			internalUtils.TestHexToFelt(
+				t,
+				"0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d",
+			),
+		},
 		Keys: [][]*felt.Felt{{
 			internalUtils.TestHexToFelt(
 				t,

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -131,9 +131,17 @@ type RPCProvider interface {
 	BlockHashAndNumber(ctx context.Context) (*BlockHashAndNumberOutput, error)
 	BlockNumber(ctx context.Context) (uint64, error)
 	BlockTransactionCount(ctx context.Context, blockID BlockID) (uint64, error)
-	BlockWithReceipts(ctx context.Context, blockID BlockID) (interface{}, error)
+	BlockWithReceipts(
+		ctx context.Context,
+		blockID BlockID,
+		responseFlags []TxnResponseFlag,
+	) (interface{}, error)
 	BlockWithTxHashes(ctx context.Context, blockID BlockID) (interface{}, error)
-	BlockWithTxs(ctx context.Context, blockID BlockID) (interface{}, error)
+	BlockWithTxs(
+		ctx context.Context,
+		blockID BlockID,
+		responseFlags []TxnResponseFlag,
+	) (interface{}, error)
 	Call(ctx context.Context, call FunctionCall, block BlockID) ([]*felt.Felt, error)
 	ChainID(ctx context.Context) (string, error)
 	Class(ctx context.Context, blockID BlockID, classHash *felt.Felt) (ClassOutput, error)
@@ -183,8 +191,13 @@ type RPCProvider interface {
 		ctx context.Context,
 		blockID BlockID,
 		index uint64,
+		responseFlags []TxnResponseFlag,
 	) (*BlockTransaction, error)
-	TransactionByHash(ctx context.Context, hash *felt.Felt) (*BlockTransaction, error)
+	TransactionByHash(
+		ctx context.Context,
+		hash *felt.Felt,
+		responseFlags []TxnResponseFlag,
+	) (*BlockTransaction, error)
 	TransactionReceipt(
 		ctx context.Context,
 		transactionHash *felt.Felt,

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -185,7 +185,11 @@ type RPCProvider interface {
 		storageProofInput StorageProofInput,
 	) (*StorageProofResult, error)
 	Syncing(ctx context.Context) (SyncStatus, error)
-	TraceBlockTransactions(ctx context.Context, blockID BlockID) (TraceBlockTxsResult, error)
+	TraceBlockTransactions(
+		ctx context.Context,
+		blockID BlockID,
+		traceFlags []TraceFlag,
+	) (TraceBlockTxsResult, error)
 	TraceTransaction(ctx context.Context, transactionHash *felt.Felt) (TxnTrace, error)
 	TransactionByBlockIDAndIndex(
 		ctx context.Context,

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -155,7 +155,7 @@ type RPCProvider interface {
 	EstimateFee(
 		ctx context.Context,
 		requests []BroadcastTxn,
-		simulationFlags []SimulationFlag,
+		simulationFlags []EstimateFeeFlag,
 		blockID BlockID,
 	) ([]FeeEstimation, error)
 	EstimateMessageFee(

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -185,7 +185,7 @@ type RPCProvider interface {
 		storageProofInput StorageProofInput,
 	) (*StorageProofResult, error)
 	Syncing(ctx context.Context) (SyncStatus, error)
-	TraceBlockTransactions(ctx context.Context, blockID BlockID) ([]Trace, error)
+	TraceBlockTransactions(ctx context.Context, blockID BlockID) (TraceBlockTxsResult, error)
 	TraceTransaction(ctx context.Context, transactionHash *felt.Felt) (TxnTrace, error)
 	TransactionByBlockIDAndIndex(
 		ctx context.Context,

--- a/rpc/provider.go
+++ b/rpc/provider.go
@@ -171,7 +171,7 @@ type RPCProvider interface {
 		blockID BlockID,
 		txns []BroadcastTxn,
 		simulationFlags []SimulationFlag,
-	) ([]SimulatedTransaction, error)
+	) (SimulateTxResult, error)
 	SpecVersion(ctx context.Context) (string, error)
 	StateUpdate(ctx context.Context, blockID BlockID) (*StateUpdateOutput, error)
 	StorageAt(

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -114,68 +114,32 @@ func (provider *Provider) TraceBlockTransactions(
 //   - simulationFlags: Describes what parts of the transaction should be executed
 //
 // Returns:
-//   - []SimulatedTransaction: The execution trace and consumed resources of the
-//     required transactions
+//   - SimulateTxResult: The execution trace and consumed resources of the
+//     required transactions + initial reads if the RETURN_INITIAL_READS flag was set.
 //   - error: An error if any occurred during the execution
 func (provider *Provider) SimulateTransactions(
 	ctx context.Context,
 	blockID BlockID,
 	txns []BroadcastTxn,
 	simulationFlags []SimulationFlag,
-) ([]SimulatedTransaction, error) {
-	var output []SimulatedTransaction
+) (SimulateTxResult, error) {
+	var output SimulateTxResult
 	if err := do(
 		ctx, provider.c, "starknet_simulateTransactions", &output, blockID, txns, simulationFlags,
 	); err != nil {
-		return nil, rpcerr.UnwrapToRPCErr(err, ErrTxnExec, ErrBlockNotFound)
+		return output, rpcerr.UnwrapToRPCErr(err, ErrTxnExec, ErrBlockNotFound)
 	}
 
 	return output, nil
 }
 
-// The set of state values fetched from the underlying state reader
-// during execution. This is a complete witness sufficient to reconstruct
-// the cached state needed for re-execution.
-type InitialReads struct {
-	// Storage entries that were read during simulation:
-	// (contract_address, storage_key) -> value
-	Storage []TraceStorageEntry `json:"storage"`
-	// Contract nonces that were read during simulation:
-	// contract_address -> nonce
-	Nonces []TraceNonce `json:"nonces"`
-	// Contract class hashes that were read during simulation:
-	// contract_address -> class_hash
-	ClassHashes []TraceClassHash `json:"class_hashes"`
-	// Class declaration statuses that were read during simulation:
-	// class_hash -> is_declared
-	DeclaredContracts []TraceDeclaredContract `json:"declared_contracts"`
-}
-
-// TraceStorageEntry is a storage entry that was read during simulation.
-// (contract_address, key) -> value
-type TraceStorageEntry struct {
-	ContractAddress *felt.Felt `json:"contract_address"`
-	Key             StorageKey `json:"key"`
-	Value           *felt.Felt `json:"value"`
-}
-
-// Contract nonce that was read during simulation.
-// contract_address -> nonce
-type TraceNonce struct {
-	ContractAddress *felt.Felt `json:"contract_address"`
-	Nonce           *felt.Felt `json:"nonce"`
-}
-
-// Contract class hashes that were read during simulation:
-// contract_address -> class_hash
-type TraceClassHash struct {
-	ContractAddress *felt.Felt `json:"contract_address"`
-	ClassHash       *felt.Felt `json:"class_hash"`
-}
-
-// Class declaration status that was read during simulation.
-// class_hash -> is_declared
-type TraceDeclaredContract struct {
-	ClassHash  *felt.Felt `json:"class_hash"`
-	IsDeclared bool       `json:"is_declared"`
+// SimutaleTxResult is the response of the `starknet_simulateTransactions`
+// RPC method. It contains an array of simulated transactions,
+type SimulateTxResult struct {
+	// The execution trace and consumed resources of the required transactions.
+	SimulatedTransactions []SimulatedTransaction `json:"simulated_transactions"`
+	// The set of state values fetched from the underlying state reader during
+	// execution for all transactions in the simulation. only present when the
+	// RETURN_INITIAL_READS flag is present in simulation_flags, otherwise, is nil.
+	InitialReads *InitialReads `json:"initial_reads"`
 }

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -99,14 +99,10 @@ func (provider *Provider) TraceBlockTransactions(
 	return output, nil
 }
 
-// SimulateTransactions simulates transactions on the blockchain.
-// Simulate a given sequence of transactions on the requested state, and generate
-// the execution traces.
-// Note that some of the transactions may revert, in which case no error is thrown,
-// but revert details can be seen on the returned trace object.
-// Note that some of the transactions may revert, this will be reflected by the
-// revert_error property in the trace. Other types of failures (e.g. unexpected error
-// or failure in the validation phase) will result in TRANSACTION_EXECUTION_ERROR.
+// SimulateTransactions returns the execution trace and consumed resources of the
+// required transactions. When RETURN_INITIAL_READS is not present in simulation_flags,
+// returns an array. When RETURN_INITIAL_READS is present in simulation_flags, returns an
+// object with simulated_transactions and initial_reads fields.
 //
 // Parameters:
 //   - ctx: The context of the function call
@@ -135,4 +131,51 @@ func (provider *Provider) SimulateTransactions(
 	}
 
 	return output, nil
+}
+
+// The set of state values fetched from the underlying state reader
+// during execution. This is a complete witness sufficient to reconstruct
+// the cached state needed for re-execution.
+type InitialReads struct {
+	// Storage entries that were read during simulation:
+	// (contract_address, storage_key) -> value
+	Storage []TraceStorageEntry `json:"storage"`
+	// Contract nonces that were read during simulation:
+	// contract_address -> nonce
+	Nonces []TraceNonce `json:"nonces"`
+	// Contract class hashes that were read during simulation:
+	// contract_address -> class_hash
+	ClassHashes []TraceClassHash `json:"class_hashes"`
+	// Class declaration statuses that were read during simulation:
+	// class_hash -> is_declared
+	DeclaredContracts []TraceDeclaredContract `json:"declared_contracts"`
+}
+
+// TraceStorageEntry is a storage entry that was read during simulation.
+// (contract_address, key) -> value
+type TraceStorageEntry struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	Key             StorageKey `json:"key"`
+	Value           *felt.Felt `json:"value"`
+}
+
+// Contract nonce that was read during simulation.
+// contract_address -> nonce
+type TraceNonce struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	Nonce           *felt.Felt `json:"nonce"`
+}
+
+// Contract class hashes that were read during simulation:
+// contract_address -> class_hash
+type TraceClassHash struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	ClassHash       *felt.Felt `json:"class_hash"`
+}
+
+// Class declaration status that was read during simulation.
+// class_hash -> is_declared
+type TraceDeclaredContract struct {
+	ClassHash  *felt.Felt `json:"class_hash"`
+	IsDeclared bool       `json:"is_declared"`
 }

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -76,6 +76,8 @@ func (provider *Provider) TraceTransaction(
 // Parameters:
 //   - ctx: the context.Context object for controlling the request
 //   - blockID: the block to retrieve the traces from. `pre_confirmed` tag is not allowed
+//   - traceFlags: Flags that indicate what additional information should be included in
+//     the trace
 //
 // Returns:
 //   - TraceBlockTxsResult: a TraceBlockTxsResult object representing the traces of
@@ -84,6 +86,7 @@ func (provider *Provider) TraceTransaction(
 func (provider *Provider) TraceBlockTransactions(
 	ctx context.Context,
 	blockID BlockID,
+	traceFlags []TraceFlag,
 ) (TraceBlockTxsResult, error) {
 	var output TraceBlockTxsResult
 	err := checkForPreConfirmed(blockID)
@@ -92,7 +95,7 @@ func (provider *Provider) TraceBlockTransactions(
 	}
 
 	if err := do(
-		ctx, provider.c, "starknet_traceBlockTransactions", &output, blockID,
+		ctx, provider.c, "starknet_traceBlockTransactions", &output, blockID, traceFlags,
 	); err != nil {
 		return output, rpcerr.UnwrapToRPCErr(err, ErrBlockNotFound)
 	}

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -132,14 +132,3 @@ func (provider *Provider) SimulateTransactions(
 
 	return output, nil
 }
-
-// SimutaleTxResult is the response of the `starknet_simulateTransactions`
-// RPC method. It contains an array of simulated transactions,
-type SimulateTxResult struct {
-	// The execution trace and consumed resources of the required transactions.
-	SimulatedTransactions []SimulatedTransaction `json:"simulated_transactions"`
-	// The set of state values fetched from the underlying state reader during
-	// execution for all transactions in the simulation. only present when the
-	// RETURN_INITIAL_READS flag is present in simulation_flags, otherwise, is nil.
-	InitialReads *InitialReads `json:"initial_reads"`
-}

--- a/rpc/trace.go
+++ b/rpc/trace.go
@@ -78,22 +78,23 @@ func (provider *Provider) TraceTransaction(
 //   - blockID: the block to retrieve the traces from. `pre_confirmed` tag is not allowed
 //
 // Returns:
-//   - []Trace: a slice of Trace objects representing the traces of transactions in the block
+//   - TraceBlockTxsResult: a TraceBlockTxsResult object representing the traces of
+//     all transactions in the block
 //   - error: an error if there was a problem retrieving the traces.
 func (provider *Provider) TraceBlockTransactions(
 	ctx context.Context,
 	blockID BlockID,
-) ([]Trace, error) {
+) (TraceBlockTxsResult, error) {
+	var output TraceBlockTxsResult
 	err := checkForPreConfirmed(blockID)
 	if err != nil {
-		return nil, err
+		return output, err
 	}
 
-	var output []Trace
 	if err := do(
 		ctx, provider.c, "starknet_traceBlockTransactions", &output, blockID,
 	); err != nil {
-		return nil, rpcerr.UnwrapToRPCErr(err, ErrBlockNotFound)
+		return output, rpcerr.UnwrapToRPCErr(err, ErrBlockNotFound)
 	}
 
 	return output, nil

--- a/rpc/trace_test.go
+++ b/rpc/trace_test.go
@@ -302,56 +302,69 @@ func TestTraceBlockTransactions(t *testing.T) {
 	testConfig := BeforeEach(t, false)
 
 	type testSetType struct {
-		BlockID     BlockID
-		ExpectedErr error
+		blockID     BlockID
+		traceFlags  []TraceFlag
+		expectedErr error
 	}
 
 	testSet := map[tests.TestEnv][]testSetType{
 		tests.MockEnv: {
 			{
-				BlockID: WithBlockTag(BlockTagLatest),
+				blockID: WithBlockTag(BlockTagLatest),
 			},
 			{
-				BlockID:     WithBlockHash(internalUtils.DeadBeef),
-				ExpectedErr: ErrBlockNotFound,
+				blockID: WithBlockTag(BlockTagLatest),
+				traceFlags: []TraceFlag{
+					TraceFlagReturnInitialReads,
+				},
 			},
 			{
-				BlockID: WithBlockTag(BlockTagPreConfirmed),
+				blockID:     WithBlockHash(internalUtils.DeadBeef),
+				expectedErr: ErrBlockNotFound,
+			},
+			{
+				blockID: WithBlockTag(BlockTagPreConfirmed),
 				// not the exact error, but it should contain it due to the checkForPreConfirmed() function
-				ExpectedErr: ErrInvalidBlockID,
+				expectedErr: ErrInvalidBlockID,
 			},
 		},
 		tests.TestnetEnv: {
 			{
-				BlockID: WithBlockNumber(99433),
+				blockID: WithBlockNumber(99433),
 			},
 			{
-				BlockID: WithBlockTag(BlockTagLatest),
+				blockID: WithBlockTag(BlockTagLatest),
 			},
 			{
-				BlockID: WithBlockTag(BlockTagL1Accepted),
+				blockID: WithBlockTag(BlockTagLatest),
+				traceFlags: []TraceFlag{
+					TraceFlagReturnInitialReads,
+				},
 			},
 			{
-				BlockID:     WithBlockHash(internalUtils.DeadBeef),
-				ExpectedErr: ErrBlockNotFound,
+				blockID: WithBlockTag(BlockTagL1Accepted),
 			},
 			{
-				BlockID: WithBlockTag(BlockTagPreConfirmed),
+				blockID:     WithBlockHash(internalUtils.DeadBeef),
+				expectedErr: ErrBlockNotFound,
+			},
+			{
+				blockID: WithBlockTag(BlockTagPreConfirmed),
 				// not the exact error, but it should contain it due to the checkForPreConfirmed() function
-				ExpectedErr: ErrInvalidBlockID,
+				expectedErr: ErrInvalidBlockID,
 			},
 		},
 	}[tests.TEST_ENV]
 
 	for _, test := range testSet {
-		t.Run(fmt.Sprintf("blockID: %v", test.BlockID), func(t *testing.T) {
-			if tests.TEST_ENV == tests.MockEnv && test.BlockID.Tag != BlockTagPreConfirmed {
+		t.Run(fmt.Sprintf("blockID: %v", test.blockID), func(t *testing.T) {
+			if tests.TEST_ENV == tests.MockEnv && test.blockID.Tag != BlockTagPreConfirmed {
 				testConfig.MockClient.EXPECT().
 					CallContextWithSliceArgs(
 						t.Context(),
 						gomock.Any(),
 						"starknet_traceBlockTransactions",
-						test.BlockID,
+						test.blockID,
 					).
 					DoAndReturn(func(_, result, _ any, args ...any) error {
 						rawResp := result.(*json.RawMessage)
@@ -364,11 +377,18 @@ func TestTraceBlockTransactions(t *testing.T) {
 							}
 						}
 
-						*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
-							t,
-							"./testData/trace/sepoliaBlockTrace_0x42a4c6a4c3dffee2cce78f04259b499437049b0084c3296da9fbbec7eda79b2.json",
-							"result",
-						)
+						if test.traceFlags != nil &&
+							slices.Contains(test.traceFlags, TraceFlagReturnInitialReads) {
+							*rawResp = json.RawMessage(
+								"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
+							)
+						} else {
+							*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
+								t,
+								"./testData/trace/sepoliaBlockTrace_0x42a4c6a4c3dffee2cce78f04259b499437049b0084c3296da9fbbec7eda79b2.json",
+								"result",
+							)
+						}
 
 						return nil
 					}).
@@ -377,18 +397,28 @@ func TestTraceBlockTransactions(t *testing.T) {
 
 			resp, err := testConfig.Provider.TraceBlockTransactions(
 				t.Context(),
-				test.BlockID,
+				test.blockID,
+				test.traceFlags,
 			)
-			if test.ExpectedErr != nil {
+			if test.expectedErr != nil {
 				require.Error(t, err)
-				assert.ErrorContains(t, err, test.ExpectedErr.Error())
+				assert.ErrorContains(t, err, test.expectedErr.Error())
 
 				return
 			}
 			require.NoError(t, err)
 
 			rawExpectedResp := testConfig.RPCSpy.LastResponse()
-			rawResp, err := json.Marshal(resp)
+			var rawResp []byte
+			// this is due to the way the RPC method returns the data. It will return an
+			// array or an object depending on the flags. If the InitialReads is nil, the
+			// node response captured by the spy will be an array, so we only marshal the
+			// Traces field to compare with the expected response.
+			if resp.InitialReads == nil {
+				rawResp, err = json.Marshal(resp.Traces)
+			} else {
+				rawResp, err = json.Marshal(resp)
+			}
 			require.NoError(t, err)
 			assert.JSONEq(t, string(rawExpectedResp), string(rawResp))
 		})

--- a/rpc/trace_test.go
+++ b/rpc/trace_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -240,11 +241,19 @@ func TestSimulateTransaction(t *testing.T) {
 								Data:    &TransactionExecErrData{},
 							}
 						}
-						*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
-							t,
-							"./testData/trace/sepoliaSimulateInvokeTxResp.json",
-							"result",
-						)
+
+						if test.SimulationFlags != nil &&
+							slices.Contains(test.SimulationFlags, ReturnInitialReads) {
+							*rawResp = json.RawMessage(
+								"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
+							)
+						} else {
+							*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
+								t,
+								"./testData/trace/sepoliaSimulateInvokeTxResp.json",
+								"result",
+							)
+						}
 
 						return nil
 					}).
@@ -270,7 +279,16 @@ func TestSimulateTransaction(t *testing.T) {
 			require.NoError(t, err)
 
 			rawExpectedResp := testConfig.RPCSpy.LastResponse()
-			rawResp, err := json.Marshal(resp)
+			var rawResp []byte
+			// this is due to the way the RPC method returns the data. It will return an
+			// array or an object depending on the flags. If the InitialReads is nil, the
+			// node response captured by the spy will be an array, so we only marshal the
+			// SimulatedTransactions field to compare with the expected response.
+			if resp.InitialReads == nil {
+				rawResp, err = json.Marshal(resp.SimulatedTransactions)
+			} else {
+				rawResp, err = json.Marshal(resp)
+			}
 			require.NoError(t, err)
 			assert.JSONEq(t, string(rawExpectedResp), string(rawResp))
 		})

--- a/rpc/trace_test.go
+++ b/rpc/trace_test.go
@@ -152,10 +152,14 @@ func TestSimulateTransaction(t *testing.T) {
 	testSet := map[tests.TestEnv][]testSetType{
 		tests.MockEnv: {
 			{
-				Description:     "valid call, all flags",
-				BlockID:         input.BlockID,
-				Txns:            input.Txns,
-				SimulationFlags: []SimulationFlag{SkipValidate, SkipFeeCharge},
+				Description: "valid call, all flags",
+				BlockID:     input.BlockID,
+				Txns:        input.Txns,
+				SimulationFlags: []SimulationFlag{
+					SkipValidate,
+					SkipFeeCharge,
+					ReturnInitialReads,
+				},
 			},
 			{
 				Description:     "block not found",
@@ -180,10 +184,14 @@ func TestSimulateTransaction(t *testing.T) {
 				SimulationFlags: input.SimulationFlags,
 			},
 			{
-				Description:     "valid call, all flags",
-				BlockID:         input.BlockID,
-				Txns:            input.Txns,
-				SimulationFlags: []SimulationFlag{SkipValidate, SkipFeeCharge},
+				Description: "valid call, all flags",
+				BlockID:     input.BlockID,
+				Txns:        input.Txns,
+				SimulationFlags: []SimulationFlag{
+					SkipValidate,
+					SkipFeeCharge,
+					ReturnInitialReads,
+				},
 			},
 			{
 				Description:     "exec error, pre confirmed",

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -12,6 +12,8 @@ import (
 // Parameters:
 //   - ctx: The context.Context object for the request.
 //   - hash: The hash of the transaction.
+//   - responseFlags: Flags that control what additional fields are included in the
+//     response. Pass nil for default behavior.
 //
 // Returns:
 //   - BlockTransaction: The retrieved Transaction
@@ -19,9 +21,12 @@ import (
 func (provider *Provider) TransactionByHash(
 	ctx context.Context,
 	hash *felt.Felt,
+	responseFlags []TxnResponseFlag,
 ) (*BlockTransaction, error) {
 	var tx BlockTransaction
-	if err := do(ctx, provider.c, "starknet_getTransactionByHash", &tx, hash); err != nil {
+	if err := do(
+		ctx, provider.c, "starknet_getTransactionByHash", &tx, hash, responseFlags,
+	); err != nil {
 		return nil, rpcerr.UnwrapToRPCErr(err, ErrHashNotFound)
 	}
 
@@ -34,6 +39,8 @@ func (provider *Provider) TransactionByHash(
 //   - ctx: The context.Context object for the request.
 //   - blockID: The ID of the block containing the transaction.
 //   - index: The index of the transaction within the block.
+//   - responseFlags: Flags that control what additional fields are included in the
+//     response. Pass nil for default behavior.
 //
 // Returns:
 //   - BlockTransaction: The retrieved Transaction object
@@ -42,10 +49,17 @@ func (provider *Provider) TransactionByBlockIDAndIndex(
 	ctx context.Context,
 	blockID BlockID,
 	index uint64,
+	responseFlags []TxnResponseFlag,
 ) (*BlockTransaction, error) {
 	var tx BlockTransaction
 	if err := do(
-		ctx, provider.c, "starknet_getTransactionByBlockIdAndIndex", &tx, blockID, index,
+		ctx,
+		provider.c,
+		"starknet_getTransactionByBlockIdAndIndex",
+		&tx,
+		blockID,
+		index,
+		responseFlags,
 	); err != nil {
 		return nil, rpcerr.UnwrapToRPCErr(err, ErrInvalidTxnIndex, ErrBlockNotFound)
 	}

--- a/rpc/transaction.go
+++ b/rpc/transaction.go
@@ -13,7 +13,7 @@ import (
 //   - ctx: The context.Context object for the request.
 //   - hash: The hash of the transaction.
 //   - responseFlags: Flags that control what additional fields are included in the
-//     response. Pass nil for default behavior.
+//     response. Pass nil for default behaviour.
 //
 // Returns:
 //   - BlockTransaction: The retrieved Transaction
@@ -40,7 +40,7 @@ func (provider *Provider) TransactionByHash(
 //   - blockID: The ID of the block containing the transaction.
 //   - index: The index of the transaction within the block.
 //   - responseFlags: Flags that control what additional fields are included in the
-//     response. Pass nil for default behavior.
+//     response. Pass nil for default behaviour.
 //
 // Returns:
 //   - BlockTransaction: The retrieved Transaction object

--- a/rpc/transaction_test.go
+++ b/rpc/transaction_test.go
@@ -3,6 +3,7 @@ package rpc
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/NethermindEth/juno/core/felt"
@@ -21,6 +22,7 @@ func TestTransactionByHash(t *testing.T) {
 
 	type testSetType struct {
 		TxHash        *felt.Felt
+		ResponseFlags []TxnResponseFlag
 		ExpectedError error
 	}
 
@@ -28,6 +30,10 @@ func TestTransactionByHash(t *testing.T) {
 		tests.MockEnv: {
 			{
 				TxHash: internalUtils.TestHexToFelt(t, "0xd109474cd037bad60a87ba0ccf3023d5f2d1cd45220c62091d41a614d38eda"),
+			},
+			{
+				TxHash:        internalUtils.TestHexToFelt(t, "0xd109474cd037bad60a87ba0ccf3023d5f2d1cd45220c62091d41a614d38eda"),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
 			},
 			{
 				TxHash:        internalUtils.DeadBeef,
@@ -39,6 +45,10 @@ func TestTransactionByHash(t *testing.T) {
 				TxHash: internalUtils.TestHexToFelt(t, "0xd109474cd037bad60a87ba0ccf3023d5f2d1cd45220c62091d41a614d38eda"),
 			},
 			{
+				TxHash:        internalUtils.TestHexToFelt(t, "0xd109474cd037bad60a87ba0ccf3023d5f2d1cd45220c62091d41a614d38eda"),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
+			{
 				TxHash:        internalUtils.DeadBeef,
 				ExpectedError: ErrHashNotFound,
 			},
@@ -46,6 +56,10 @@ func TestTransactionByHash(t *testing.T) {
 		tests.IntegrationEnv: {
 			{
 				TxHash: internalUtils.TestHexToFelt(t, "0x38f7c9972f2b6f6d92d474cf605a077d154d58de938125180e7c87f22c5b019"),
+			},
+			{
+				TxHash:        internalUtils.TestHexToFelt(t, "0x38f7c9972f2b6f6d92d474cf605a077d154d58de938125180e7c87f22c5b019"),
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
 			},
 			{
 				TxHash:        internalUtils.DeadBeef,
@@ -73,18 +87,30 @@ func TestTransactionByHash(t *testing.T) {
 							}
 						}
 
-						*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
-							t,
-							"./testData/txnWithHash/sepoliaTxn.json",
-							"result",
-						)
+						if test.ResponseFlags != nil {
+							if slices.Contains(test.ResponseFlags, TxnFlagIncludeProofFacts) {
+								*rawResp = json.RawMessage(
+									"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
+								)
+							}
+						} else {
+							*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
+								t,
+								"./testData/txnWithHash/sepoliaTxn.json",
+								"result",
+							)
+						}
 
 						return nil
 					}).
 					Times(1)
 			}
 
-			tx, err := testConfig.Provider.TransactionByHash(t.Context(), test.TxHash)
+			tx, err := testConfig.Provider.TransactionByHash(
+				t.Context(),
+				test.TxHash,
+				test.ResponseFlags,
+			)
 			if test.ExpectedError != nil {
 				require.Error(t, err)
 				assert.EqualError(t, err, test.ExpectedError.Error())
@@ -111,6 +137,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 	type testSetType struct {
 		BlockID       BlockID
 		Index         uint64
+		ResponseFlags []TxnResponseFlag
 		ExpectedError error
 	}
 
@@ -119,6 +146,11 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 			{
 				BlockID: WithBlockHash(internalUtils.TestHexToFelt(t, "0x873a3d4e1159ccecec5488e07a31c9a4ba8c6d2365b6aa48d39f5fd54e6bd0")),
 				Index:   3,
+			},
+			{
+				BlockID:       WithBlockHash(internalUtils.TestHexToFelt(t, "0x873a3d4e1159ccecec5488e07a31c9a4ba8c6d2365b6aa48d39f5fd54e6bd0")),
+				Index:         3,
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
 			},
 			{
 				BlockID:       WithBlockHash(internalUtils.TestHexToFelt(t, "0x873a3d4e1159ccecec5488e07a31c9a4ba8c6d2365b6aa48d39f5fd54e6bd0")),
@@ -148,11 +180,21 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 				BlockID: WithBlockTag(BlockTagLatest),
 				Index:   0,
 			},
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				Index:         0,
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
+			},
 		},
 		tests.IntegrationEnv: {
 			{
 				BlockID: WithBlockNumber(1_300_000),
 				Index:   0,
+			},
+			{
+				BlockID:       WithBlockTag(BlockTagLatest),
+				Index:         0,
+				ResponseFlags: []TxnResponseFlag{TxnFlagIncludeProofFacts},
 			},
 		},
 	}[tests.TEST_ENV]
@@ -185,11 +227,19 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 							}
 						}
 
-						*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
-							t,
-							"./testData/txnWithHash/sepoliaTxn.json",
-							"result",
-						)
+						if test.ResponseFlags != nil {
+							if slices.Contains(test.ResponseFlags, TxnFlagIncludeProofFacts) {
+								*rawResp = json.RawMessage(
+									"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
+								)
+							}
+						} else {
+							*rawResp = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
+								t,
+								"./testData/txnWithHash/sepoliaTxn.json",
+								"result",
+							)
+						}
 
 						return nil
 					}).
@@ -200,6 +250,7 @@ func TestTransactionByBlockIdAndIndex(t *testing.T) {
 				t.Context(),
 				test.BlockID,
 				test.Index,
+				test.ResponseFlags,
 			)
 			if test.ExpectedError != nil {
 				require.Error(t, err)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -22,10 +22,6 @@ type StorageEntry struct {
 	Value *felt.Felt `json:"value"`
 }
 
-// type StorageEntries struct {
-// 	StorageEntry []StorageEntry
-// }
-
 // ContractStorageDiffItem is a change in a single storage item
 type ContractStorageDiffItem struct {
 	// ContractAddress is the contract address for which the state changed

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -416,3 +416,64 @@ func (fs TxnFinalityStatus) MarshalJSON() ([]byte, error) {
 func (fs TxnFinalityStatus) String() string {
 	return string(fs)
 }
+
+// Flags that control what additional fields are included in transaction responses.
+type TxnResponseFlag int
+
+const (
+	// Include proof_facts field when available (only for transactions submitted
+	// through the gateway with proof facts).
+	TxnFlagIncludeProofFacts TxnResponseFlag = iota
+)
+
+// String returns the string representation of the TxnResponseFlag.
+//
+// Parameters:
+//
+//	none
+//
+// Returns:
+//   - string: the string representation of the TxnResponseFlag
+func (f TxnResponseFlag) String() string {
+	if f == TxnFlagIncludeProofFacts {
+		return "INCLUDE_PROOF_FACTS"
+	}
+
+	return "UNKNOWN_FLAG"
+}
+
+// MarshalJSON marshals the TxnResponseFlag into JSON.
+//
+// Parameters:
+//
+//	none
+//
+// Returns:
+//   - []byte: a byte slice
+//   - error: an error if any
+func (f TxnResponseFlag) MarshalJSON() ([]byte, error) {
+	return []byte(strconv.Quote(f.String())), nil
+}
+
+// UnmarshalJSON unmarshals the JSON data into a TxnResponseFlag.
+//
+// Parameters:
+//
+//	none
+//
+// Returns:
+//   - error: an error if the unmarshaling fails
+func (f *TxnResponseFlag) UnmarshalJSON(data []byte) error {
+	unquoted, err := strconv.Unquote(string(data))
+	if err != nil {
+		return err
+	}
+	switch unquoted {
+	case "INCLUDE_PROOF_FACTS":
+		*f = TxnFlagIncludeProofFacts
+	default:
+		return fmt.Errorf("unknown flag: %s", data)
+	}
+
+	return nil
+}

--- a/rpc/types_broadcast_transaction.go
+++ b/rpc/types_broadcast_transaction.go
@@ -15,7 +15,28 @@ var (
 	_ BroadcastTxn = (*BroadcastDeployAccountTxnV3)(nil)
 )
 
-type BroadcastInvokeTxnV3 = InvokeTxnV3
+type BroadcastInvokeTxnV3 struct {
+	Type           TransactionType        `json:"type"`
+	SenderAddress  *felt.Felt             `json:"sender_address"`
+	Calldata       []*felt.Felt           `json:"calldata"`
+	Version        TransactionVersion     `json:"version"`
+	Signature      []*felt.Felt           `json:"signature"`
+	Nonce          *felt.Felt             `json:"nonce"`
+	ResourceBounds *ResourceBoundsMapping `json:"resource_bounds"`
+	Tip            U64                    `json:"tip"`
+	// The data needed to allow the paymaster to pay for the transaction in native tokens
+	PayMasterData []*felt.Felt `json:"paymaster_data"`
+	// The data needed to deploy the account contract from which this tx will be initiated
+	AccountDeploymentData []*felt.Felt `json:"account_deployment_data"`
+	// The storage domain of the account's nonce (an account has a nonce per DA mode)
+	NonceDataMode DataAvailabilityMode `json:"nonce_data_availability_mode"`
+	// The storage domain of the account's balance from which fee will be charged
+	FeeMode DataAvailabilityMode `json:"fee_data_availability_mode"`
+	// Optional proof facts for the transaction
+	ProofFacts []*felt.Felt `json:"proof_facts"`
+	// Optional proof for the transaction
+	Proof []int `json:"proof"`
+}
 
 type BroadcastDeployAccountTxnV3 = DeployAccountTxnV3
 

--- a/rpc/types_event.go
+++ b/rpc/types_event.go
@@ -1,6 +1,11 @@
 package rpc
 
-import "github.com/NethermindEth/juno/core/felt"
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/NethermindEth/juno/core/felt"
+)
 
 type OrderedEvent struct {
 	// The order of the event within the transaction
@@ -43,10 +48,42 @@ type EventFilter struct {
 	FromBlock BlockID `json:"from_block,omitempty"`
 	// ToBlock to block
 	ToBlock BlockID `json:"to_block,omitempty"`
-	// A list of addresses from which events should originate.
-	Address []*felt.Felt `json:"address,omitempty"`
+	// A contract address or a list of addresses from which events should originate"
+	Address AddressList `json:"address,omitempty"`
 	// Keys the values used to filter the events
 	Keys [][]*felt.Felt `json:"keys,omitempty"`
+}
+
+// AddressList is a list of addresses from which events should originate.
+// If the list contains a single address, it will be marshalled
+// as a single string in the JSON response, otherwise as an array.
+type AddressList []*felt.Felt
+
+// MarshalJSON marshals the AddressList into JSON.
+func (al AddressList) MarshalJSON() ([]byte, error) {
+	if len(al) == 1 {
+		return json.Marshal(al[0])
+	}
+
+	return json.Marshal([]*felt.Felt(al))
+}
+
+// UnmarshalJSON unmarshals the JSON data into an AddressList.
+func (al *AddressList) UnmarshalJSON(data []byte) error {
+	var arr []*felt.Felt
+	err := json.Unmarshal(data, &arr)
+	if err != nil {
+		var singleF *felt.Felt
+		err2 := json.Unmarshal(data, &singleF)
+		if err2 != nil {
+			return errors.Join(errors.New("failed to unmarshal address list"), err, err2)
+		}
+		*al = AddressList{singleF}
+	} else {
+		*al = arr
+	}
+
+	return nil
 }
 
 // EventsInput is the input for the 'starknet_getEvents' method.

--- a/rpc/types_event.go
+++ b/rpc/types_event.go
@@ -96,8 +96,9 @@ type EventsInput struct {
 // EventSubscriptionInput is the input for the 'starknet_subscribeEvents' method.
 
 type EventSubscriptionInput struct {
-	// (Optional) Filter events by from_address which emitted the event
-	FromAddress *felt.Felt `json:"from_address,omitempty"`
+	// (Optional) A contract address or a list of addresses from which events
+	// should originate
+	FromAddress AddressList `json:"from_address,omitempty"`
 	// (Optional) Per key (by position), designate the possible values to be
 	// matched for events to be returned. Empty array designates 'any' value
 	Keys [][]*felt.Felt `json:"keys,omitempty"`

--- a/rpc/types_event.go
+++ b/rpc/types_event.go
@@ -43,8 +43,8 @@ type EventFilter struct {
 	FromBlock BlockID `json:"from_block,omitempty"`
 	// ToBlock to block
 	ToBlock BlockID `json:"to_block,omitempty"`
-	// Address from contract
-	Address *felt.Felt `json:"address,omitempty"`
+	// A list of addresses from which events should originate.
+	Address []*felt.Felt `json:"address,omitempty"`
 	// Keys the values used to filter the events
 	Keys [][]*felt.Felt `json:"keys,omitempty"`
 }

--- a/rpc/types_event_test.go
+++ b/rpc/types_event_test.go
@@ -1,0 +1,143 @@
+package rpc
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/NethermindEth/starknet.go/internal/tests"
+	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAddressList_MarshalJSON tests the MarshalJSON method of the AddressList type.
+func TestAddressList_MarshalJSON(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+
+	for _, test := range []struct {
+		name string
+		al   AddressList
+		want string
+	}{
+		{
+			name: "single address marshals as string",
+			al:   AddressList{internalUtils.TestHexToFelt(t, "0x1234")},
+			want: `"0x1234"`,
+		},
+		{
+			name: "multiple addresses marshal as array",
+			al: AddressList{
+				internalUtils.TestHexToFelt(t, "0x1234"),
+				internalUtils.TestHexToFelt(t, "0x5678"),
+			},
+			want: `["0x1234","0x5678"]`,
+		},
+		{
+			name: "empty list marshals as empty array",
+			al:   AddressList{},
+			want: `[]`,
+		},
+		{
+			name: "nil list marshals as null",
+			al:   nil,
+			want: `null`,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(test.al)
+			require.NoError(t, err)
+			assert.JSONEq(t, test.want, string(b))
+		})
+	}
+}
+
+// TestAddressList_UnmarshalJSON tests the UnmarshalJSON method of the AddressList type.
+func TestAddressList_UnmarshalJSON(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+
+	for _, test := range []struct {
+		name    string
+		input   string
+		want    AddressList
+		wantErr bool
+	}{
+		{
+			name:  "single address as string",
+			input: `"0x1234"`,
+			want:  AddressList{internalUtils.TestHexToFelt(t, "0x1234")},
+		},
+		{
+			name:  "multiple addresses as array",
+			input: `["0x1234","0x5678"]`,
+			want: AddressList{
+				internalUtils.TestHexToFelt(t, "0x1234"),
+				internalUtils.TestHexToFelt(t, "0x5678"),
+			},
+		},
+		{
+			name:  "empty array",
+			input: `[]`,
+			want:  AddressList{},
+		},
+		{
+			name:    "invalid JSON",
+			input:   `{invalid}`,
+			wantErr: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var al AddressList
+			err := json.Unmarshal([]byte(test.input), &al)
+			if test.wantErr {
+				require.Error(t, err)
+
+				return
+			}
+			require.NoError(t, err)
+			require.Len(t, al, len(test.want))
+			for i := range al {
+				assert.Equal(t, test.want[i], al[i])
+			}
+		})
+	}
+}
+
+// TestAddressList_RoundTrip tests that marshalling and unmarshalling produces the same result.
+func TestAddressList_RoundTrip(t *testing.T) {
+	tests.RunTestOn(t, tests.MockEnv)
+
+	for _, test := range []struct {
+		name string
+		al   AddressList
+	}{
+		{
+			name: "single address round trip",
+			al:   AddressList{internalUtils.TestHexToFelt(t, "0xdeadbeef")},
+		},
+		{
+			name: "multiple addresses round trip",
+			al: AddressList{
+				internalUtils.TestHexToFelt(t, "0x1"),
+				internalUtils.TestHexToFelt(t, "0x2"),
+				internalUtils.TestHexToFelt(t, "0x3"),
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Marshal
+			b, err := json.Marshal(test.al)
+			require.NoError(t, err)
+
+			// Unmarshal
+			var result AddressList
+			err = json.Unmarshal(b, &result)
+			require.NoError(t, err)
+
+			// Compare
+			require.Len(t, result, len(test.al))
+			for i := range result {
+				assert.Equal(t, test.al[i], result[i])
+			}
+		})
+	}
+}

--- a/rpc/types_trace.go
+++ b/rpc/types_trace.go
@@ -311,3 +311,50 @@ func unmarshalTraceTxn(t interface{}) (TxnTrace, error) {
 
 	return nil, fmt.Errorf("unknown transaction type: %v", t)
 }
+
+// The set of state values fetched from the underlying state reader
+// during execution. This is a complete witness sufficient to reconstruct
+// the cached state needed for re-execution.
+type InitialReads struct {
+	// Storage entries that were read during simulation:
+	// (contract_address, storage_key) -> value
+	Storage []TraceStorageEntry `json:"storage"`
+	// Contract nonces that were read during simulation:
+	// contract_address -> nonce
+	Nonces []TraceNonce `json:"nonces"`
+	// Contract class hashes that were read during simulation:
+	// contract_address -> class_hash
+	ClassHashes []TraceClassHash `json:"class_hashes"`
+	// Class declaration statuses that were read during simulation:
+	// class_hash -> is_declared
+	DeclaredContracts []TraceDeclaredContract `json:"declared_contracts"`
+}
+
+// TraceStorageEntry is a storage entry that was read during simulation.
+// (contract_address, key) -> value
+type TraceStorageEntry struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	Key             StorageKey `json:"key"`
+	Value           *felt.Felt `json:"value"`
+}
+
+// Contract nonce that was read during simulation.
+// contract_address -> nonce
+type TraceNonce struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	Nonce           *felt.Felt `json:"nonce"`
+}
+
+// Contract class hashes that were read during simulation:
+// contract_address -> class_hash
+type TraceClassHash struct {
+	ContractAddress *felt.Felt `json:"contract_address"`
+	ClassHash       *felt.Felt `json:"class_hash"`
+}
+
+// Class declaration status that was read during simulation.
+// class_hash -> is_declared
+type TraceDeclaredContract struct {
+	ClassHash  *felt.Felt `json:"class_hash"`
+	IsDeclared bool       `json:"is_declared"`
+}

--- a/rpc/types_trace.go
+++ b/rpc/types_trace.go
@@ -312,6 +312,43 @@ func unmarshalTraceTxn(t interface{}) (TxnTrace, error) {
 	return nil, fmt.Errorf("unknown transaction type: %v", t)
 }
 
+// SimutaleTxResult is the response of the `starknet_simulateTransactions`
+// RPC method. It contains an array of simulated transactions,
+type SimulateTxResult struct {
+	// The execution trace and consumed resources of the required transactions.
+	SimulatedTransactions []SimulatedTransaction `json:"simulated_transactions"`
+	// The set of state values fetched from the underlying state reader during
+	// execution for all transactions in the simulation. only present when the
+	// RETURN_INITIAL_READS flag is present in simulation_flags, otherwise, is nil.
+	InitialReads *InitialReads `json:"initial_reads"`
+}
+
+// UnmarshalJSON unmarshals the data into a SimulateTxResult object.
+func (s *SimulateTxResult) UnmarshalJSON(data []byte) error {
+	var txs []SimulatedTransaction
+	if err := json.Unmarshal(data, &txs); err != nil {
+		type aux SimulateTxResult
+		var sresp aux
+		err2 := json.Unmarshal(data, &sresp)
+		if err2 != nil {
+			return errors.Join(
+				errors.New("failed to unmarshal simulated transactions"),
+				err,
+				err2,
+			)
+		}
+		*s = SimulateTxResult(sresp)
+
+		return nil
+	}
+	*s = SimulateTxResult{
+		SimulatedTransactions: txs,
+		InitialReads:          nil,
+	}
+
+	return nil
+}
+
 // The set of state values fetched from the underlying state reader
 // during execution. This is a complete witness sufficient to reconstruct
 // the cached state needed for re-execution.

--- a/rpc/types_trace.go
+++ b/rpc/types_trace.go
@@ -9,6 +9,14 @@ import (
 	internalUtils "github.com/NethermindEth/starknet.go/internal/utils"
 )
 
+// Flags that indicate how to estimate the fee of a given transaction.
+// By default, the sequencer behaviour is replicated locally.
+type EstimateFeeFlag string
+
+const (
+	EstimateFeeSkipValidate EstimateFeeFlag = "SKIP_VALIDATE"
+)
+
 // Flags that indicate how to simulate a given transaction. By default, the
 // sequencer behaviour is replicated locally (enough funds are expected to be
 // in the account, and fee will be deducted from the balance before the

--- a/rpc/types_trace.go
+++ b/rpc/types_trace.go
@@ -21,12 +21,37 @@ const (
 // sequencer behaviour is replicated locally (enough funds are expected to be
 // in the account, and fee will be deducted from the balance before the
 // simulation of the next transaction). To skip the fee charge, use
-// the SKIP_FEE_CHARGE flag.
+// the SKIP_FEE_CHARGE flag. When RETURN_INITIAL_READS is present, the node
+// returns the minimal set of concrete state values fetched from the underlying
+// state reader during execution for all transactions in the simulation."
 type SimulationFlag string
 
 const (
+	// Flag to skip the fee charge when simulating a transaction.
 	SkipFeeCharge SimulationFlag = "SKIP_FEE_CHARGE"
-	SkipValidate  SimulationFlag = "SKIP_VALIDATE"
+	// Flag to skip the validation when simulating a transaction.
+	SkipValidate SimulationFlag = "SKIP_VALIDATE"
+	// With this flag, the node returns the minimal set of concrete state values
+	// fetched from the underlying state reader during execution for all
+	// transactions in the simulation.
+	ReturnInitialReads SimulationFlag = "RETURN_INITIAL_READS"
+)
+
+// Flags that indicate what additional information should be included in the trace.
+// When RETURN_INITIAL_READS is present, the node returns the minimal set of concrete
+// state values fetched from the underlying state reader during execution for all
+// transactions in the block. Returns an empty object instead of INITIAL_READS when
+// the execution trace for the referenced block is inconsistent with the canonical
+// block trace.
+type TraceFlag string
+
+const (
+	// Flag to return the minimal set of concrete
+	// state values fetched from the underlying state reader during execution for all
+	// transactions in the block. Returns an empty object instead of INITIAL_READS when
+	// the execution trace for the referenced block is inconsistent with the canonical
+	// block trace.
+	TraceFlagReturnInitialReads TraceFlag = "RETURN_INITIAL_READS"
 )
 
 type SimulatedTransaction struct {

--- a/rpc/types_trace.go
+++ b/rpc/types_trace.go
@@ -312,13 +312,52 @@ func unmarshalTraceTxn(t interface{}) (TxnTrace, error) {
 	return nil, fmt.Errorf("unknown transaction type: %v", t)
 }
 
+// TraceBlockTxResult is the response of the `starknet_traceBlockTransactions`
+// RPC method. It contains an array of traces of all transactions in the block.
+type TraceBlockTxsResult struct {
+	// The traces of all transactions in the block
+	Traces []Trace `json:"traces"`
+	// The set of state values fetched from the underlying state reader during
+	// execution for all transactions in the block. Returns an empty object
+	// instead of INITIAL_READS when the execution trace for the referenced
+	// block is inconsistent with the canonical block trace. Only present when
+	// RETURN_INITIAL_READS is present in trace_flags, otherwise, is nil.
+	InitialReads *InitialReads `json:"initial_reads"`
+}
+
+// UnmarshalJSON unmarshals the data into a TraceBlockTxsResult object.
+func (t *TraceBlockTxsResult) UnmarshalJSON(data []byte) error {
+	var txs []Trace
+	if err := json.Unmarshal(data, &txs); err != nil {
+		type aux TraceBlockTxsResult
+		var tresp aux
+		err2 := json.Unmarshal(data, &tresp)
+		if err2 != nil {
+			return errors.Join(
+				errors.New("failed to unmarshal traces"),
+				err,
+				err2,
+			)
+		}
+		*t = TraceBlockTxsResult(tresp)
+
+		return nil
+	}
+	*t = TraceBlockTxsResult{
+		Traces:       txs,
+		InitialReads: nil,
+	}
+
+	return nil
+}
+
 // SimutaleTxResult is the response of the `starknet_simulateTransactions`
 // RPC method. It contains an array of simulated transactions,
 type SimulateTxResult struct {
 	// The execution trace and consumed resources of the required transactions.
 	SimulatedTransactions []SimulatedTransaction `json:"simulated_transactions"`
 	// The set of state values fetched from the underlying state reader during
-	// execution for all transactions in the simulation. only present when the
+	// execution for all transactions in the simulation. Only present when the
 	// RETURN_INITIAL_READS flag is present in simulation_flags, otherwise, is nil.
 	InitialReads *InitialReads `json:"initial_reads"`
 }

--- a/rpc/types_transaction.go
+++ b/rpc/types_transaction.go
@@ -53,6 +53,8 @@ type InvokeTxnV3 struct {
 	NonceDataMode DataAvailabilityMode `json:"nonce_data_availability_mode"`
 	// The storage domain of the account's balance from which fee will be charged
 	FeeMode DataAvailabilityMode `json:"fee_data_availability_mode"`
+	// Optional proof facts for the transaction
+	ProofFacts []*felt.Felt `json:"proof_facts"`
 }
 
 type L1HandlerTxn struct {

--- a/rpc/types_transaction.go
+++ b/rpc/types_transaction.go
@@ -361,7 +361,19 @@ type SubNewTxnsInput struct {
 	// Optional: Filter transaction receipts to only include transactions sent
 	// by the specified addresses
 	SenderAddress []*felt.Felt `json:"sender_address,omitempty"`
+	// Optional: Tags that control what additional fields are included in
+	// transaction responses
+	Tags []SubscriptionTag `json:"tags,omitempty"`
 }
+
+// Tags that control what additional fields are included in subscription responses.
+type SubscriptionTag string
+
+const (
+	// Include proof_facts field when available (only for INVOKE transactions
+	// with version 3)
+	SubTagIncludeProofFacts SubscriptionTag = "INCLUDE_PROOF_FACTS"
+)
 
 // TxnWithHashAndStatus is the response of the
 // starknet_subscribeNewTransactions subscription.

--- a/rpc/types_transaction_interfaces.go
+++ b/rpc/types_transaction_interfaces.go
@@ -125,6 +125,14 @@ func (tx InvokeTxnV3) GetVersion() TransactionVersion {
 	return tx.Version
 }
 
+func (tx BroadcastInvokeTxnV3) GetType() TransactionType {
+	return tx.Type
+}
+
+func (tx BroadcastInvokeTxnV3) GetVersion() TransactionVersion {
+	return tx.Version
+}
+
 // Declare transactions
 func (tx DeclareTxnV0) GetType() TransactionType {
 	return tx.Type
@@ -217,6 +225,10 @@ func (tx InvokeTxnV1) GetCalldata() []*felt.Felt {
 }
 
 func (tx InvokeTxnV3) GetCalldata() []*felt.Felt {
+	return tx.Calldata
+}
+
+func (tx BroadcastInvokeTxnV3) GetCalldata() []*felt.Felt {
 	return tx.Calldata
 }
 

--- a/rpc/utils.go
+++ b/rpc/utils.go
@@ -62,7 +62,7 @@ func EstimateTip(
 	tip U64,
 	err error,
 ) {
-	rawLatestBlock, err := provider.BlockWithTxs(ctx, WithBlockTag(BlockTagLatest))
+	rawLatestBlock, err := provider.BlockWithTxs(ctx, WithBlockTag(BlockTagLatest), nil)
 	if err != nil {
 		return tip, fmt.Errorf("failed to get latest block: %w", err)
 	}

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -1013,11 +1013,13 @@ func TestSubscribeTransactionStatus(t *testing.T) {
 		)
 		t.Parallel()
 
-		tsetup := BeforeEach(t, true)
+		// a separate setup in order to avoid race conditions
+		// (the WS spy only works with a single subscription)
+		tempsetup := BeforeEach(t, true)
 
 		// getting a random new PRE_CONFIRMED transaction
 		txns := make(chan *TxnWithHashAndStatus)
-		sub, err := tsetup.WsProvider.SubscribeNewTransactions(
+		sub, err := tempsetup.WsProvider.SubscribeNewTransactions(
 			t.Context(),
 			txns,
 			&SubNewTxnsInput{
@@ -1029,6 +1031,8 @@ func TestSubscribeTransactionStatus(t *testing.T) {
 
 		txn := <-txns
 		require.NotNil(t, txn)
+
+		tsetup := BeforeEach(t, true)
 
 		status := make(chan *NewTxnStatus)
 		sub2, err := tsetup.WsProvider.SubscribeTransactionStatus(

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
 	"time"
 
@@ -793,6 +794,12 @@ func TestSubscribeNewTransactions(t *testing.T) {
 			},
 		},
 		{
+			description: "with tag INCLUDE_PROOF_FACTS",
+			input: &SubNewTxnsInput{
+				Tags: []SubscriptionTag{SubTagIncludeProofFacts},
+			},
+		},
+		{
 			description: "all filters",
 			input: &SubNewTxnsInput{
 				SenderAddress: []*felt.Felt{randAddress},
@@ -802,6 +809,7 @@ func TestSubscribeNewTransactions(t *testing.T) {
 					TxnStatusPreConfirmed,
 					TxnStatusAcceptedOnL2,
 				},
+				Tags: []SubscriptionTag{SubTagIncludeProofFacts},
 			},
 		},
 		{
@@ -845,11 +853,20 @@ func TestSubscribeNewTransactions(t *testing.T) {
 							}
 						}
 
-						msg := internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
-							t,
-							"./testData/ws/sepoliaNewTxns.json",
-							"params", "result",
-						)
+						var msg json.RawMessage
+						if input.Tags != nil &&
+							slices.Contains(input.Tags, SubTagIncludeProofFacts) {
+							t.Fatal("waiting for nodes to implement rpcv0.10.1")
+							msg = json.RawMessage(
+								"waiting for nodes to implement rpcv0.10.1, so that we can get the data",
+							)
+						} else {
+							msg = internalUtils.TestUnmarshalJSONFileToType[json.RawMessage](
+								t,
+								"./testData/ws/sepoliaNewTxns.json",
+								"params", "result",
+							)
+						}
 
 						go func() {
 							for {

--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -241,7 +241,7 @@ func TestSubscribeEvents(t *testing.T) {
 		{
 			description: "from address only",
 			input: &EventSubscriptionInput{
-				FromAddress: fromAddress,
+				FromAddress: AddressList{fromAddress},
 			},
 		},
 		{
@@ -273,7 +273,7 @@ func TestSubscribeEvents(t *testing.T) {
 		{
 			description: "all filters",
 			input: &EventSubscriptionInput{
-				FromAddress:    fromAddress,
+				FromAddress:    AddressList{fromAddress},
 				Keys:           [][]*felt.Felt{{key}},
 				SubBlockID:     new(SubscriptionBlockID).WithBlockNumber(blockNumber - 1000),
 				FinalityStatus: TxnFinalityStatusAcceptedOnL2,

--- a/utils/transactions.go
+++ b/utils/transactions.go
@@ -122,6 +122,8 @@ func BuildInvokeTxn(
 		AccountDeploymentData: []*felt.Felt{},
 		NonceDataMode:         rpc.DAModeL1,
 		FeeMode:               rpc.DAModeL1,
+		ProofFacts:            []*felt.Felt{},
+		Proof:                 []int{},
 	}
 
 	return &invokeTxn


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core RPC method signatures and transaction hashing/encoding, which is broadly breaking for consumers and could affect correctness if flag handling or proof-fact hashing diverges from node behavior.
> 
> **Overview**
> Updates the RPC/client APIs to align with Starknet RPC `v0.10.1-rc.2`, adding support for **proof-related fields** and **flag-controlled response shapes**.
> 
> Provider methods are extended to accept new flag parameters (`responseFlags` for block/transaction lookups, `traceFlags` for `TraceBlockTransactions`), `EstimateFee` switches to `[]EstimateFeeFlag`, and both `SimulateTransactions` and `TraceBlockTransactions` now return wrapper result types that can include `initial_reads` when `RETURN_INITIAL_READS` is requested.
> 
> Transaction/event types are updated accordingly: `InvokeTxnV3` gains `ProofFacts`, `BroadcastInvokeTxnV3` becomes a distinct struct including `Proof`/`ProofFacts`, event filters/subscriptions now accept single-or-multi addresses via `AddressList`, and websocket new-tx subscriptions add `Tags` (e.g. include proof facts). Account fee-estimation options and examples/tests/mocks are updated to match the new signatures, and invoke hashing now conditionally incorporates `ProofFacts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11cd4d5df090e1f6f0fb79b3dfbff719b877f01a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->