### PR TITLE
fix(rpc): add division by zero guard

### DIFF
--- a/rpc/utils_test.go
+++ b/rpc/utils_test.go
@@ -103,6 +103,12 @@ func TestProvider_EstimateTip(t *testing.T) {
 
 // getTipAverageFromBlock returns the average of the tips from all transactions in the block
 func getTipAverageFromBlock(t *testing.T, block *Block) uint64 {
+	t.Helper()
+
+	if len(block.Transactions) == 0 {
+		return 0
+	}
+
 	var tipCounter uint64
 	for _, tnx := range block.Transactions {
 		// get the tip from the transaction


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk test-only change that prevents a possible division-by-zero panic when the captured block contains no transactions.
> 
> **Overview**
> Improves `rpc/utils_test.go` by marking `getTipAverageFromBlock` as a test helper and returning `0` when the block has no transactions, preventing a division-by-zero when computing the average tip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6feef1335ffb75ce80122f7a726a407df4c0eeb7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->